### PR TITLE
Secure schema registry using a password

### DIFF
--- a/app/api/base_api.rb
+++ b/app/api/base_api.rb
@@ -1,0 +1,14 @@
+# This module provides shared configuration for the Schema Registry API
+module BaseAPI
+  extend ActiveSupport::Concern
+
+  included do
+    format :json
+
+    helpers ::Helpers::ErrorHelper
+
+    http_basic do |_username, password|
+      password == Rails.configuration.x.app_password
+    end
+  end
+end

--- a/app/api/schema_api.rb
+++ b/app/api/schema_api.rb
@@ -1,7 +1,5 @@
 class SchemaAPI < Grape::API
-  format :json
-
-  helpers ::Helpers::ErrorHelper
+  include BaseAPI
 
   rescue_from ActiveRecord::RecordNotFound do
     schema_not_found!

--- a/app/api/subject_api.rb
+++ b/app/api/subject_api.rb
@@ -1,7 +1,5 @@
 class SubjectAPI < Grape::API
-  format :json
-
-  helpers ::Helpers::ErrorHelper
+  include BaseAPI
 
   LATEST_VERSION = 'latest'.freeze
 
@@ -13,7 +11,7 @@ class SubjectAPI < Grape::API
     invalid_avro_schema!
   end
 
-  rescue_from :all do |e|
+  rescue_from :all do
     server_error!
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,5 +33,7 @@ module AvroSchemaRegistry
     # Grape support
     config.paths.add(File.join('app', 'api'), glob: File.join('**', '*.rb'))
     config.autoload_paths += Dir[Rails.root.join('app', 'api', '*')]
+
+    config.x.app_password = ENV['SCHEMA_REGISTRY_PASSWORD'] || 'avro'
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,4 +64,6 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  config.x.app_password = ENV.fetch('SCHEMA_REGISTRY_PASSWORD')
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,7 +6,7 @@ require 'spec_helper'
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
-# Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 # Checks for pending migration and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
@@ -18,4 +18,6 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
 
   config.filter_rails_from_backtrace!
+
+  config.include RequestHelper, type: :request
 end

--- a/spec/requests/schema_api_spec.rb
+++ b/spec/requests/schema_api_spec.rb
@@ -2,6 +2,11 @@ require 'rails_helper'
 
 describe SchemaAPI do
   describe "GET /schemas/ids/:id" do
+    it "is secured by Basic auth" do
+      unauthorized_get('/schemas/ids/1')
+      expect(status).to eq(401)
+    end
+
     context "when the schema is found" do
       let(:schema) { create(:schema) }
       let(:expected) do

--- a/spec/requests/subject_api_spec.rb
+++ b/spec/requests/subject_api_spec.rb
@@ -15,6 +15,11 @@ describe SubjectAPI do
       expect(response).to be_ok
       expect(response.body).to be_json_eql(expected)
     end
+
+    it "is secured by Basic auth" do
+      unauthorized_get('/subjects')
+      expect(status).to eq(401)
+    end
   end
 
   describe "GET /subjects/:name/versions" do
@@ -32,6 +37,11 @@ describe SubjectAPI do
       end
     end
 
+    it "is secured by Basic auth" do
+      unauthorized_get('/subjects/name')
+      expect(status).to eq(401)
+    end
+
     context "when the subject does not exist" do
       let(:name) { 'fnord' }
 
@@ -44,6 +54,11 @@ describe SubjectAPI do
   end
 
   describe "GET /subjects/:name/versions/:version_id" do
+    it "is secured by Basic auth" do
+      unauthorized_get('/subjects/name/versions/1')
+      expect(status).to eq(401)
+    end
+
     context "when the subject and version exists" do
       let!(:other_schema_version) { create(:schema_version) }
       let(:version) { create(:schema_version) }
@@ -100,6 +115,11 @@ describe SubjectAPI do
   end
 
   describe "POST /subjects/:name/versions" do
+    it "is secured by Basic auth" do
+      unauthorized_post('/subjects/name/versions')
+      expect(status).to eq(401)
+    end
+
     context "with an invalid avro schema" do
       let(:subject_name) { 'invalid' }
 
@@ -248,6 +268,11 @@ describe SubjectAPI do
   end
 
   describe "POST /subjects/:name" do
+    it "is secured by Basic auth" do
+      unauthorized_post('/subjects/name')
+      expect(status).to eq(401)
+    end
+
     context "when the schema exists for the subject" do
       let!(:version) { create(:schema_version) }
       let(:subject_name) { version.subject.name }

--- a/spec/support/helpers/request_helper.rb
+++ b/spec/support/helpers/request_helper.rb
@@ -1,0 +1,23 @@
+# Helper to set Basic authentication for requests.
+module RequestHelper
+  extend ActiveSupport::Concern
+
+  GRAPE_ROUTE_METHODS = %i(get post put head delete patch).freeze
+
+  included do
+    GRAPE_ROUTE_METHODS.each do |method|
+      # Alias the original method so we can explicitly call it as unauthorized_<method>.
+      alias_method("unauthorized_#{method}", method)
+
+      # Overrides the http method to automatically set the authorization header
+      # for HTTP Basic auth
+      define_method(method) do |path, parameters = nil, headers_or_env = nil|
+        headers = headers_or_env.try(:dup) || {}
+        basic_auth = ActionController::HttpAuthentication::Basic
+                       .encode_credentials('ignored', Rails.configuration.x.app_password)
+        headers['Authorization'] ||= basic_auth
+        send("unauthorized_#{method}", path, parameters, headers)
+      end
+    end
+  end
+end


### PR DESCRIPTION
HTTP Basic auth is used to secure the service using a password that can be specified via the environment.

Prime: @jturkel 
