### PR TITLE
Allow period in subject names

### DIFF
--- a/app/api/subject_api.rb
+++ b/app/api/subject_api.rb
@@ -33,7 +33,7 @@ class SubjectAPI < Grape::API
   end
 
   params { requires :name, type: String, desc: 'Subject name' }
-  segment ':name' do
+  segment ':name', requirements: { name: /[a-zA-Z_][\w\.]*/ } do
     desc 'Get a list of versions registered under the specified subject.'
     get :versions do
       SchemaVersion.for_subject_name(params[:name])

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -10,10 +10,10 @@
 
 FactoryGirl.define do
   factory :subject, aliases: [:value_subject] do
-    sequence(:name) { |n| "subject-#{n}-value" }
+    sequence(:name) { |n| "subject_#{n}_value" }
 
     factory :key_subject do
-      sequence(:name) { |n| "subject-#{n}-key" }
+      sequence(:name) { |n| "subject_#{n}_key" }
     end
   end
 

--- a/spec/requests/subject_api_spec.rb
+++ b/spec/requests/subject_api_spec.rb
@@ -32,6 +32,58 @@ describe SubjectAPI do
   end
 
   describe "GET /subjects/:name/versions" do
+
+    context "supported subject names" do
+      # This is only being tested for one representative route under
+      # /subjects/:name
+      shared_examples_for "a supported subject name" do |desc, name|
+        let(:subject) { create(:subject, name: name) }
+        let!(:schema_version) { create(:version, subject: subject) }
+
+        it "supports #{desc}" do
+          get("/subjects/#{subject.name}/versions")
+          expect(response).to be_ok
+          expect(response.body).to eq([schema_version.version].to_json)
+        end
+      end
+
+      shared_examples_for "an unsupported subject name" do |desc, name|
+        it "does not support #{desc}" do
+          expect do
+            get("/subjects/#{name}/versions")
+          end.to raise_error(ActionController::RoutingError)
+        end
+      end
+
+      it_behaves_like 'a supported subject name',
+                      'a name containing a period',
+                      'com.example.foo'
+
+      it_behaves_like 'a supported subject name',
+                      'a name beginning with an underscore',
+                      '_underscore'
+
+      it_behaves_like 'a supported subject name',
+                      'a name containing a digit',
+                      'number5'
+
+      it_behaves_like 'a supported subject name',
+                      'a name containing mixed case',
+                      'UPPER_lower_0123456789'
+
+      it_behaves_like 'an unsupported subject name',
+                      'a name beginning with a digit',
+                      '5alive'
+
+      it_behaves_like 'an unsupported subject name',
+                      'a name containing a hyphen',
+                      'foo-bar'
+
+      it_behaves_like 'an unsupported subject name',
+                      'a name beginning with a period',
+                      '.com'
+    end
+
     context "when the subject exists" do
       let(:subject) { create(:subject) }
       let!(:schema_versions) { Array.new(1) { create(:version, subject: subject) } }


### PR DESCRIPTION
I believe that Rails supports periods in route parameters by default, but for Grape the requirement must be relaxed explicitly.

The restrictions enforced here are based on the expectation that the subject name will be a concatenation of an Avro namespace and name: http://avro.apache.org/docs/current/spec.html#names

@rlburkes - you're prime. The README for this repo is still lacking. This is a Rails app using Grape that implements this [API](http://docs.confluent.io/2.0.1/schema-registry/docs/api.html) (minus the Compatibility part).

CC: @jturkel 
