### PR TITLE
Add the option to disable authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ schema with each message.
 ## Overview
 
 This application provides the same API as the Confluent
-[Schema Registry](http://docs.confluent.io/2.0.1/schema-registry/docs/api.html).
+[Schema Registry](http://docs.confluent.io/3.0.0/schema-registry/docs/api.html).
 
 The service is implemented as a Rails 4.2 application and stores Avro schemas in
 Postgres. The API is implemented using [Grape](https://github.com/ruby-grape/grape).
@@ -30,7 +30,7 @@ are stored by the registry.
 
 ## Setup
 
-The application is written using Ruby 2.3. Start the service using the following
+The application is written using Ruby 2.3.1. Start the service using the following
 steps:
 
 ```bash
@@ -45,14 +45,17 @@ By default the service runs on port 21000.
 
 ## Security
 
-The service is secured using HTTP Basic authentication and should be with SSL.
-The default password for the service is 'avro' but can be via the environment
-as `SCHEMA_REGISTRY_PASSWORD`.
+The service is secured using HTTP Basic authentication and should be used with
+SSL. The default password for the service is 'avro' but it can be set via
+the environment as `SCHEMA_REGISTRY_PASSWORD`.
+
+Authentication can be disabled by setting `DISABLE_PASSWORD` to 'true' in the
+environment.
 
 ## Usage
 
 For more details on the REST API see the Confluent
-[documentation](http://docs.confluent.io/2.0.1/schema-registry/docs/api.html).
+[documentation](http://docs.confluent.io/3.0.0/schema-registry/docs/api.html).
 
 A [client](https://github.com/dasch/avro_turf/blob/master/lib/avro_turf/schema_registry.rb)
 (see [AvroTurf](https://github.com/dasch/avro_turf)) can be used to

--- a/app/api/base_api.rb
+++ b/app/api/base_api.rb
@@ -1,3 +1,5 @@
+require 'grape/middleware/optional_auth'
+
 # This module provides shared configuration for the Schema Registry API
 module BaseAPI
   extend ActiveSupport::Concern
@@ -18,8 +20,11 @@ module BaseAPI
 
     helpers ::Helpers::ErrorHelper
 
-    http_basic do |_username, password|
-      password == Rails.configuration.x.app_password
-    end
+    use Grape::Middleware::OptionalAuth,
+        type: :http_basic,
+        realm: 'API Authorization',
+        proc: ->(_username, password) do
+          password == Rails.configuration.x.app_password
+        end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,7 @@ module AvroSchemaRegistry
     config.paths.add(File.join('app', 'api'), glob: File.join('**', '*.rb'))
     config.autoload_paths += Dir[Rails.root.join('app', 'api', '*')]
 
+    config.x.disable_password = ENV['DISABLE_PASSWORD'] == 'true'
     config.x.app_password = ENV['SCHEMA_REGISTRY_PASSWORD'] || 'avro'
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -65,5 +65,7 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.x.app_password = ENV.fetch('SCHEMA_REGISTRY_PASSWORD')
+  unless config.x.disable_password
+    config.x.app_password = ENV.fetch('SCHEMA_REGISTRY_PASSWORD')
+  end
 end

--- a/lib/grape/middleware/optional_auth.rb
+++ b/lib/grape/middleware/optional_auth.rb
@@ -1,0 +1,11 @@
+module Grape
+  module Middleware
+    # This middleware allows HTTP Basic/Digest middleware to be bypassed based
+    # on configuration.
+    class OptionalAuth < Grape::Middleware::Auth::Base
+      def call(env)
+        Rails.configuration.x.disable_password ? app.call(env) : super
+      end
+    end
+  end
+end

--- a/spec/requests/compatibility_api_spec.rb
+++ b/spec/requests/compatibility_api_spec.rb
@@ -47,9 +47,11 @@ describe CompatibilityAPI do
       end
     end
 
-    it "is secured by Basic auth" do
-      unauthorized_post('/compatibility/subjects/name/versions/1', schema: {})
-      expect(status).to eq(401)
+    it_behaves_like "a secure endpoint" do
+      let(:action) do
+        unauthorized_post("/compatibility/subjects/#{subject_name}/versions/#{version.version}",
+                          schema: schema)
+      end
     end
 
     context "when the schema is invalid" do

--- a/spec/requests/config_api_spec.rb
+++ b/spec/requests/config_api_spec.rb
@@ -12,9 +12,8 @@ describe ConfigAPI do
       expect(response.body).to be_json_eql(expected)
     end
 
-    it "is secured by Basic auth" do
-      unauthorized_get('/config')
-      expect(status).to eq(401)
+    it_behaves_like "a secure endpoint" do
+      let(:action) { unauthorized_get('/config') }
     end
   end
 
@@ -28,9 +27,8 @@ describe ConfigAPI do
       expect(Config.global.compatibility).to eq(compatibility)
     end
 
-    it "is secured by Basic auth" do
-      unauthorized_put('/config', compatibility: compatibility)
-      expect(status).to eq(401)
+    it_behaves_like "a secure endpoint" do
+      let(:action) { unauthorized_put('/config', compatibility: compatibility) }
     end
 
     context "when the compatibility value is not uppercase" do
@@ -58,9 +56,8 @@ describe ConfigAPI do
     let(:subject) { create(:subject) }
     let(:compatibility) { Compatibility.global }
 
-    it "is secured by Basic auth" do
-      unauthorized_get("/config/#{subject.name}")
-      expect(status).to eq(401)
+    it_behaves_like "a secure endpoint" do
+      let(:action) { unauthorized_get("/config/#{subject.name}") }
     end
 
     context "when compatibility is set for the subject" do
@@ -127,9 +124,10 @@ describe ConfigAPI do
       end
     end
 
-    it "is secured by Basic auth" do
-      unauthorized_put("/config/#{subject.name}", compatibility: compatibility)
-      expect(status).to eq(401)
+    it_behaves_like "a secure endpoint" do
+      let(:action) do
+        unauthorized_put("/config/#{subject.name}", compatibility: compatibility)
+      end
     end
 
     context "when the subject does not exist" do

--- a/spec/requests/schema_api_spec.rb
+++ b/spec/requests/schema_api_spec.rb
@@ -4,9 +4,8 @@ describe SchemaAPI do
   describe "GET /schemas/ids/:id" do
     let(:schema) { create(:schema) }
 
-    it "is secured by Basic auth" do
-      unauthorized_get('/schemas/ids/1')
-      expect(status).to eq(401)
+    it_behaves_like "a secure endpoint" do
+      let(:action) { unauthorized_get("/schemas/ids/#{schema.id}") }
     end
 
     context "content type" do

--- a/spec/requests/subject_api_spec.rb
+++ b/spec/requests/subject_api_spec.rb
@@ -43,9 +43,8 @@ describe SubjectAPI do
       expect(response.body).to be_json_eql(expected)
     end
 
-    it "is secured by Basic auth" do
-      unauthorized_get('/subjects')
-      expect(status).to eq(401)
+    it_behaves_like "a secure endpoint" do
+      let(:action) { unauthorized_get('/subjects') }
     end
   end
 
@@ -116,9 +115,9 @@ describe SubjectAPI do
       end
     end
 
-    it "is secured by Basic auth" do
-      unauthorized_get('/subjects/name')
-      expect(status).to eq(401)
+    it_behaves_like "a secure endpoint" do
+      let(:version) { create(:version) }
+      let(:action) { unauthorized_get("/subjects/#{version.subject.name}/versions") }
     end
 
     context "when the subject does not exist" do
@@ -133,9 +132,11 @@ describe SubjectAPI do
   end
 
   describe "GET /subjects/:name/versions/:version_id" do
-    it "is secured by Basic auth" do
-      unauthorized_get('/subjects/name/versions/1')
-      expect(status).to eq(401)
+    it_behaves_like "a secure endpoint" do
+      let(:version) { create(:schema_version) }
+      let(:action) do
+        unauthorized_get("/subjects/#{version.subject.name}/versions/#{version.version}")
+      end
     end
 
     context "when the subject and version exists" do
@@ -194,9 +195,12 @@ describe SubjectAPI do
   end
 
   describe "POST /subjects/:name/versions" do
-    it "is secured by Basic auth" do
-      unauthorized_post('/subjects/name/versions')
-      expect(status).to eq(401)
+    it_behaves_like "a secure endpoint" do
+      let(:version) { create(:version) }
+      let(:action) do
+        unauthorized_post("/subjects/#{version.subject.name}/versions",
+                          schema: version.schema.json)
+      end
     end
 
     context "with an invalid avro schema" do
@@ -367,9 +371,11 @@ describe SubjectAPI do
   end
 
   describe "POST /subjects/:name" do
-    it "is secured by Basic auth" do
-      unauthorized_post('/subjects/name')
-      expect(status).to eq(401)
+    it_behaves_like "a secure endpoint" do
+      let(:version) { create(:version) }
+      let(:action) do
+        unauthorized_post("/subjects/#{version.subject.name}", schema: version.schema.json)
+      end
     end
 
     context "when the schema exists for the subject" do

--- a/spec/support/contexts/secure_endpoint.rb
+++ b/spec/support/contexts/secure_endpoint.rb
@@ -1,0 +1,17 @@
+shared_examples_for "a secure endpoint" do
+  context "when HTTP Basic password is disabled" do
+    before do
+      allow(Rails.configuration.x).to receive(:disable_password).and_return(true)
+    end
+
+    it "allows unauthorized requests" do
+      action
+      expect(status).to eq(200)
+    end
+  end
+
+  it "is secured by Basic auth" do
+    action
+    expect(status).to eq(401)
+  end
+end

--- a/spec/support/rails_configuration_custom.rb
+++ b/spec/support/rails_configuration_custom.rb
@@ -1,0 +1,9 @@
+# Monkey-patch Rails::Application::Configuration::Custom to allow configuration
+# to be stubbed.
+module Rails
+  class Application::Configuration::Custom # rubocop:disable Style/ClassAndModuleChildren
+    def respond_to_missing?(*)
+      true
+    end
+  end
+end


### PR DESCRIPTION
A simple subclass of the Grape Auth middleware is introduced that allows basic auth to be skipped based on configuration. The configuration is set based on a `DISABLE_PASSWORD` environment variable.

Prime: @jturkel 