### PR TITLE
Add staging environment

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -34,7 +34,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,0 +1,8 @@
+require Rails.root.join('config/environments/production')
+
+Rails.application.configure do
+  # Settings specified here will take precedence over those in
+  # config/environments/production.rb.
+
+  config.log_level = :debug
+end


### PR DESCRIPTION
Not much that needs to differ here between staging and production, but adding staging keeps some of the deployment setup consistent.

I did change the log level for production as Rails `:debug` default never made sense to me.

Prime: @jturkel 