### PR TITLE
Add full compatiblity check

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'rails', '4.2.7'
 gem 'pg'
 gem 'rails-api'
 gem 'grape'
-gem 'avro-salsify-fork', '1.9.0.3.pre2', require: 'avro'
+gem 'avro-salsify-fork', '1.9.0.3', require: 'avro'
 gem 'ice_nine', require: 'ice_nine/core_ext/object'
 gem 'private_attr', require: 'private_attr/everywhere'
 

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'rails', '4.2.7'
 gem 'pg'
 gem 'rails-api'
 gem 'grape'
-gem 'avro-salsify-fork', '1.9.0.2', require: 'avro'
+gem 'avro-salsify-fork', '1.9.0.3.pre2', require: 'avro'
 gem 'ice_nine', require: 'ice_nine/core_ext/object'
 gem 'private_attr', require: 'private_attr/everywhere'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ GEM
       rake (>= 0.8.7)
     arel (6.0.3)
     ast (2.3.0)
-    avro-salsify-fork (1.9.0.3.pre2)
+    avro-salsify-fork (1.9.0.3)
       multi_json
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
@@ -208,7 +208,7 @@ PLATFORMS
 
 DEPENDENCIES
   annotate
-  avro-salsify-fork (= 1.9.0.3.pre2)
+  avro-salsify-fork (= 1.9.0.3)
   bugsnag
   factory_girl_rails
   grape

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ GEM
       rake (>= 0.8.7)
     arel (6.0.3)
     ast (2.3.0)
-    avro-salsify-fork (1.9.0.2)
+    avro-salsify-fork (1.9.0.3.pre2)
       multi_json
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
@@ -208,7 +208,7 @@ PLATFORMS
 
 DEPENDENCIES
   annotate
-  avro-salsify-fork (= 1.9.0.2)
+  avro-salsify-fork (= 1.9.0.3.pre2)
   bugsnag
   factory_girl_rails
   grape

--- a/app/models/schema_registry.rb
+++ b/app/models/schema_registry.rb
@@ -24,12 +24,15 @@ module SchemaRegistry
     end
   end
 
-  # This implements a very basic check of schema compatibility.
-  # To implement the complete compatibility check something like this needs to
-  # be ported to to the ruby gem:
-  # https://github.com/apache/avro/blob/master/lang/java/avro/src/main/java/org/apache/avro/io/parsing/ResolvingGrammarGenerator.java
+  # If a version/fork of avro that defines Avro::SchemaCompability is
+  # present, use the full compatibility check, otherwise fall back to
+  # match_schemas.
   def self.check(readers_schema, writers_schema)
-    Avro::IO::DatumReader.match_schemas(writers_schema, readers_schema)
+    if defined?(Avro::SchemaCompatibility)
+      Avro::SchemaCompatibility.can_read?(writers_schema, readers_schema)
+    else
+      Avro::IO::DatumReader.match_schemas(writers_schema, readers_schema)
+    end
   end
   private_class_method :check
 end

--- a/spec/requests/subject_api_spec.rb
+++ b/spec/requests/subject_api_spec.rb
@@ -235,7 +235,7 @@ describe SubjectAPI do
       let(:subject) { version.subject }
       let(:json) do
         JSON.parse(version.schema.json).tap do |h|
-          h['fields'] << { type: :string, name: :additional_field }
+          h['fields'] << { type: :string, name: :additional_field, default: '' }
         end.to_json
       end
 
@@ -287,7 +287,7 @@ describe SubjectAPI do
         let(:subject_name) { new_subject.name }
         let(:new_json) do
           JSON.parse(json).tap do |avro|
-            avro['fields'] << { name: :new, type: :string }
+            avro['fields'] << { name: :new, type: :string, default: '' }
           end.to_json
         end
         let(:new_schema) { create(:schema, json: new_json) }
@@ -343,7 +343,7 @@ describe SubjectAPI do
         let(:subject_name) { previous_version.subject.name }
         let(:json) do
           JSON.parse(previous_version.schema.json).tap do |avro|
-            avro['fields'] << { name: :extra, type: :string }
+            avro['fields'] << { name: :extra, type: :string, default: '' }
           end.to_json
         end
         let(:fingerprint) { Schemas::FingerprintGenerator.call(json) }

--- a/spec/schema_registry_spec.rb
+++ b/spec/schema_registry_spec.rb
@@ -8,7 +8,7 @@ describe SchemaRegistry do
     subject { described_class.compatible?(compatibility, old_json, new_json) }
 
     before do
-      allow(Avro::IO::DatumReader).to receive(:match_schemas).and_call_original
+      allow(Avro::SchemaCompatibility).to receive(:can_read?).and_call_original
     end
 
     context "when compatibility is nil" do
@@ -26,7 +26,7 @@ describe SchemaRegistry do
 
       it "does not perform any check" do
         expect(subject).to eq(true)
-        expect(Avro::IO::DatumReader).not_to have_received(:match_schemas)
+        expect(Avro::SchemaCompatibility).not_to have_received(:can_read?)
       end
     end
 
@@ -35,7 +35,7 @@ describe SchemaRegistry do
 
       it "performs a check with the old schema as the readers schema" do
         subject
-        expect(Avro::IO::DatumReader).to have_received(:match_schemas).with(new_schema, old_schema)
+        expect(Avro::SchemaCompatibility).to have_received(:can_read?).with(new_schema, old_schema)
       end
     end
 
@@ -44,7 +44,7 @@ describe SchemaRegistry do
 
       it "performs a check with the new schema as the readers schema" do
         subject
-        expect(Avro::IO::DatumReader).to have_received(:match_schemas).with(old_schema, new_schema)
+        expect(Avro::SchemaCompatibility).to have_received(:can_read?).with(old_schema, new_schema)
       end
     end
 
@@ -53,8 +53,8 @@ describe SchemaRegistry do
 
       it "performs a check with each schema as the readers schema" do
         subject
-        expect(Avro::IO::DatumReader).to have_received(:match_schemas).with(new_schema, old_schema)
-        expect(Avro::IO::DatumReader).to have_received(:match_schemas).with(old_schema, new_schema)
+        expect(Avro::SchemaCompatibility).to have_received(:can_read?).with(new_schema, old_schema)
+        expect(Avro::SchemaCompatibility).to have_received(:can_read?).with(old_schema, new_schema)
       end
     end
   end


### PR DESCRIPTION
This change updates the schema registry to perform a full Avro schema compatibility check using the implementation from a fork of the avro gem.

The check is still just performed against a single schema, the latest version if a new version is being registered.

Prime: @jturkel 