### PR TITLE
Support transitive compatibility checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 !/log/.keep
 /tmp
 .idea
+coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # avro-schema-registry
 
+## v0.4.0
+- Use `avro-salsify-fork` v1.9.0.3.
+- Implement full schema compatibility check and transitive options from
+  Confluent Schema Registry API v3.1.0.
+
 ## v0.3.0
 - Use `heroku_rails_deploy` gem.
 

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'private_attr', require: 'private_attr/everywhere'
 group :test do
   gem 'rspec-rails'
   gem 'json_spec'
+  gem 'simplecov'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,7 @@ GEM
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.2.5)
+    docile (1.1.5)
     equalizer (0.0.11)
     erubis (2.7.0)
     factory_girl (4.5.0)
@@ -183,6 +184,11 @@ GEM
     salsify_rubocop (0.46.0)
       rubocop (~> 0.46.0)
       rubocop-rspec (~> 1.8.0)
+    simplecov (0.11.2)
+      docile (~> 1.1.0)
+      json (~> 1.8)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
     spring (1.6.4)
     sprockets (3.7.0)
       concurrent-ruby (~> 1.0)
@@ -224,6 +230,7 @@ DEPENDENCIES
   rails-api
   rspec-rails
   salsify_rubocop
+  simplecov
   spring
 
 RUBY VERSION

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ schema with each message.
 ## Overview
 
 This application provides the same API as the Confluent
-[Schema Registry](http://docs.confluent.io/3.0.0/schema-registry/docs/api.html).
+[Schema Registry](http://docs.confluent.io/3.1.0/schema-registry/docs/api.html).
 
 The service is implemented as a Rails 4.2 application and stores Avro schemas in
 Postgres. The API is implemented using [Grape](https://github.com/ruby-grape/grape).
@@ -63,7 +63,7 @@ environment.
 ## Usage
 
 For more details on the REST API see the Confluent
-[documentation](http://docs.confluent.io/3.0.0/schema-registry/docs/api.html).
+[documentation](http://docs.confluent.io/3.1.0/schema-registry/docs/api.html).
 
 A [client](https://github.com/dasch/avro_turf/blob/master/lib/avro_turf/schema_registry.rb)
 (see [AvroTurf](https://github.com/dasch/avro_turf)) can be used to
@@ -85,17 +85,6 @@ id = client.register('test_subject', avro_json_schema)
 client.fetch(id)
 # => avro_json_schema
 ```
-
-### Compatibility
-
-Support for compatibility checking is incomplete. The full Confluent Schema
-Registry API is supported but compatibility checks are based on
-[Avro::IO::DatumReader.match_schemas](https://github.com/apache/avro/blob/branch-1.8/lang/ruby/lib/avro/io.rb#L222)
-from the [avro gem](https://github.com/apache/avro/tree/branch-1.8/lang/ruby).
-
-This is a basic check that ensures the top-level Avro type and name match.
-
-In the future, a complete implementation of compatibility checking may be added.
 
 ## Tests
 

--- a/app/api/compatibility_api.rb
+++ b/app/api/compatibility_api.rb
@@ -22,9 +22,7 @@ class CompatibilityAPI < Grape::API
   post '/subjects/:subject/versions/:version_id', requirements: { subject: Subject::NAME_REGEXP } do
     with_schema_version(params[:subject], params[:version_id]) do |schema_version|
       status 200
-      { is_compatible: SchemaRegistry.compatible?(schema_version.subject.config.try(:compatibility),
-                                                  schema_version.schema.json,
-                                                  params[:schema]) }
+      { is_compatible: SchemaRegistry.compatible?(params[:schema], version: schema_version) }
     end
   end
 end

--- a/app/models/compatibility.rb
+++ b/app/models/compatibility.rb
@@ -1,11 +1,19 @@
 module Compatibility
 
   module Constants
-    BOTH = 'BOTH'.freeze
+    BOTH = 'BOTH'.freeze # deprecated
     BACKWARD = 'BACKWARD'.freeze
+    BACKWARD_TRANSITIVE = 'BACKWARD_TRANSITIVE'.freeze
     FORWARD = 'FORWARD'.freeze
+    FORWARD_TRANSITIVE = 'FORWARD_TRANSITIVE'.freeze
+    FULL = 'FULL'.freeze
+    FULL_TRANSITIVE = 'FULL_TRANSITIVE'.freeze
     NONE = 'NONE'.freeze
-    VALUES = Set.new([BOTH, BACKWARD, FORWARD, NONE]).freeze
+
+    VALUES = Set.new([BOTH, BACKWARD, BACKWARD_TRANSITIVE, BACKWARD, FORWARD,
+                      FORWARD_TRANSITIVE, FULL, FULL_TRANSITIVE, NONE]).freeze
+
+    TRANSITIVE_VALUES = Set.new([BACKWARD_TRANSITIVE, FORWARD_TRANSITIVE, FULL_TRANSITIVE]).freeze
   end
 
   class InvalidCompatibilityLevelError < StandardError

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -12,7 +12,7 @@
 class Config < ActiveRecord::Base
 
   # This default differs from the Confluent default of BACKWARD
-  DEFAULT_COMPATIBILITY = Compatibility::Constants::BOTH
+  DEFAULT_COMPATIBILITY = Compatibility::Constants::FULL_TRANSITIVE
   COMPATIBILITY_NAME = 'compatibility'.freeze
 
   belongs_to :subject
@@ -23,7 +23,7 @@ class Config < ActiveRecord::Base
             allow_nil: true
 
   def compatibility=(value)
-    super(value.upcase)
+    super(value.try(:upcase))
   end
 
   def self.global

--- a/app/models/schema_registry.rb
+++ b/app/models/schema_registry.rb
@@ -2,37 +2,67 @@ module SchemaRegistry
   InvalidAvroSchemaError = Class.new(StandardError)
   IncompatibleAvroSchemaError = Class.new(StandardError)
 
-  def self.compatible?(compatibility, old_json, new_json)
-    direction = compatibility || Compatibility.global
-    old_schema = Schemas::Parse.call(old_json)
-    new_schema = Schemas::Parse.call(new_json)
-    case direction
-    when Compatibility::Constants::NONE
-      true
-    when Compatibility::Constants::BACKWARD
-      check(old_schema, new_schema)
-    when Compatibility::Constants::FORWARD
-      check(new_schema, old_schema)
-    when Compatibility::Constants::BOTH
-      check(old_schema, new_schema) && check(new_schema, old_schema)
+  extend self
+
+  def compatible?(new_json, version:)
+    compatibility = version.subject.config.try(:compatibility) || Compatibility.global
+
+    if Compatibility::Constants::TRANSITIVE_VALUES.include?(compatibility)
+      check_all_versions(compatibility, new_json, version.subject)
+    else
+      check_single_version(compatibility, version.schema.json, new_json)
     end
   end
 
-  def self.compatible!(compatibility, old_json, new_json)
-    unless compatible?(compatibility, old_json, new_json)
+  def compatible!(new_json, version:)
+    unless compatible?(new_json, version: version)
       raise IncompatibleAvroSchemaError
     end
   end
 
+  private
+
   # If a version/fork of avro that defines Avro::SchemaCompability is
   # present, use the full compatibility check, otherwise fall back to
   # match_schemas.
-  def self.check(readers_schema, writers_schema)
+  def check(readers_schema, writers_schema)
     if defined?(Avro::SchemaCompatibility)
       Avro::SchemaCompatibility.can_read?(writers_schema, readers_schema)
     else
       Avro::IO::DatumReader.match_schemas(writers_schema, readers_schema)
     end
   end
-  private_class_method :check
+
+  def check_single_version(compatibility, old_json, new_json)
+    old_schema = Schemas::Parse.call(old_json)
+    new_schema = Schemas::Parse.call(new_json)
+
+    case compatibility
+    when Compatibility::Constants::NONE
+      true
+    when Compatibility::Constants::BACKWARD
+      check(old_schema, new_schema)
+    when Compatibility::Constants::FORWARD
+      check(new_schema, old_schema)
+    when Compatibility::Constants::FULL, Compatibility::Constants::BOTH
+      check(old_schema, new_schema) && check(new_schema, old_schema)
+    end
+  end
+
+  def check_all_versions(compatibility, new_json, subject)
+    new_schema = Schemas::Parse.call(new_json)
+    json_schemas = subject.versions.order(version: :desc).joins(:schema).pluck('version', 'schemas.json').map(&:last)
+
+    case compatibility
+    when Compatibility::Constants::BACKWARD_TRANSITIVE
+      json_schemas.all? { |json| check(Schemas::Parse.call(json), new_schema) }
+    when Compatibility::Constants::FORWARD_TRANSITIVE
+      json_schemas.all? { |json| check(new_schema, Schemas::Parse.call(json)) }
+    when Compatibility::Constants::FULL_TRANSITIVE
+      json_schemas.all? do |json|
+        old_schema = Schemas::Parse.call(json)
+        check(old_schema, new_schema) && check(new_schema, old_schema)
+      end
+    end
+  end
 end

--- a/app/models/schemas/register_new_version.rb
+++ b/app/models/schemas/register_new_version.rb
@@ -72,9 +72,7 @@ module Schemas
       else
         # Create new schema version for subject
         SchemaVersion.transaction do
-          SchemaRegistry.compatible!(latest_version.subject.config.try(:compatibility),
-                                     latest_version.schema.json,
-                                     json)
+          SchemaRegistry.compatible!(json, version: latest_version)
           yield if block_given?
           new_schema_version_for_subject!(schema.id, latest_version)
         end

--- a/spec/factories/configs.rb
+++ b/spec/factories/configs.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :config do
+    subject
+    compatibility { Config::DEFAULT_COMPATIBILITY }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,4 +1,7 @@
 ENV['RAILS_ENV'] ||= 'test'
+require 'simplecov'
+SimpleCov.start 'rails'
+
 require File.expand_path('../../config/environment', __FILE__)
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?

--- a/spec/requests/compatibility_api_spec.rb
+++ b/spec/requests/compatibility_api_spec.rb
@@ -11,9 +11,7 @@ describe CompatibilityAPI do
     let(:compatibility) { nil }
 
     it "tests compatibility of the schema with the version of the subject's schema" do
-      allow(SchemaRegistry).to receive(:compatible?).with(compatibility,
-                                                          version.schema.json,
-                                                          schema).and_return(true)
+      allow(SchemaRegistry).to receive(:compatible?).with(schema, version: version).and_return(true)
       post("/compatibility/subjects/#{subject_name}/versions/#{version.version}", schema: schema)
       expect(response).to be_ok
       expect(response.body).to be_json_eql({ is_compatible: true }.to_json)
@@ -25,9 +23,7 @@ describe CompatibilityAPI do
       before { version.subject.create_config!(compatibility: compatibility) }
 
       it "tests compatibility of the schema with the version of the subject's schema" do
-        allow(SchemaRegistry).to receive(:compatible?).with(compatibility,
-                                                            version.schema.json,
-                                                            schema).and_return(true)
+        allow(SchemaRegistry).to receive(:compatible?).with(schema, version: version).and_return(true)
         post("/compatibility/subjects/#{subject_name}/versions/#{version.version}", schema: schema)
         expect(response).to be_ok
         expect(response.body).to be_json_eql({ is_compatible: true }.to_json)
@@ -38,9 +34,7 @@ describe CompatibilityAPI do
       let(:second_version) { create(:schema_version, subject: version.subject, version: 2) }
 
       it "tests compatibility of the schema with the latest version of the subject's schema" do
-        allow(SchemaRegistry).to receive(:compatible?).with(compatibility,
-                                                            second_version.schema.json,
-                                                            schema).and_return(true)
+        allow(SchemaRegistry).to receive(:compatible?).with(schema, version: second_version).and_return(true)
         post("/compatibility/subjects/#{subject_name}/versions/latest", schema: schema)
         expect(response).to be_ok
         expect(response.body).to be_json_eql({ is_compatible: true }.to_json)

--- a/spec/schema_registry_spec.rb
+++ b/spec/schema_registry_spec.rb
@@ -1,11 +1,16 @@
 describe SchemaRegistry do
-  let(:old_json) { build(:schema).json }
+  let(:registry_subject) { version.subject }
+  let(:version) { create(:schema_version) }
   let(:new_json) { build(:schema).json }
-  let(:old_schema) { Avro::Schema.parse(old_json) }
+  let(:old_schema) { Avro::Schema.parse(version.schema.json) }
   let(:new_schema) { Avro::Schema.parse(new_json) }
 
+  before do
+    create(:config, subject_id: version.subject_id, compatibility: compatibility) if compatibility
+  end
+
   describe ".compatible?" do
-    subject { described_class.compatible?(compatibility, old_json, new_json) }
+    subject(:check) { described_class.compatible?(new_json, version: version) }
 
     before do
       allow(Avro::SchemaCompatibility).to receive(:can_read?).and_call_original
@@ -16,7 +21,7 @@ describe SchemaRegistry do
 
       it "uses the global Compatibility level" do
         allow(Compatibility).to receive(:global).and_call_original
-        subject
+        check
         expect(Compatibility).to have_received(:global)
       end
     end
@@ -25,7 +30,7 @@ describe SchemaRegistry do
       let(:compatibility) { 'NONE' }
 
       it "does not perform any check" do
-        expect(subject).to eq(true)
+        expect(check).to eq(true)
         expect(Avro::SchemaCompatibility).not_to have_received(:can_read?)
       end
     end
@@ -34,7 +39,7 @@ describe SchemaRegistry do
       let(:compatibility) { 'BACKWARD' }
 
       it "performs a check with the old schema as the readers schema" do
-        subject
+        check
         expect(Avro::SchemaCompatibility).to have_received(:can_read?).with(new_schema, old_schema)
       end
     end
@@ -43,18 +48,75 @@ describe SchemaRegistry do
       let(:compatibility) { 'FORWARD' }
 
       it "performs a check with the new schema as the readers schema" do
-        subject
+        check
         expect(Avro::SchemaCompatibility).to have_received(:can_read?).with(old_schema, new_schema)
       end
     end
 
-    context "when compatibility is BOTH" do
+    context "when compatibility is BOTH (deprecated)" do
       let(:compatibility) { 'BOTH' }
 
       it "performs a check with each schema as the readers schema" do
-        subject
+        check
         expect(Avro::SchemaCompatibility).to have_received(:can_read?).with(new_schema, old_schema)
         expect(Avro::SchemaCompatibility).to have_received(:can_read?).with(old_schema, new_schema)
+      end
+    end
+
+    context "when compatibility is FULL" do
+      let(:compatibility) { 'FULL' }
+
+      it "performs a check with each schema as the readers schema" do
+        check
+        expect(Avro::SchemaCompatibility).to have_received(:can_read?).with(new_schema, old_schema)
+        expect(Avro::SchemaCompatibility).to have_received(:can_read?).with(old_schema, new_schema)
+      end
+    end
+
+    context "transitive checks" do
+      let!(:second_version) { create(:schema_version, subject: registry_subject, version: 2) }
+      let(:second_schema) { Avro::Schema.parse(second_version.schema.json) }
+      let(:can_read_args) { [] }
+
+      before do
+        # rspec checks for ordered calls with have_received were not working so
+        # expectations are checked directly based on captured args
+        allow(Avro::SchemaCompatibility).to receive(:can_read?) do |*args|
+          can_read_args << args
+          true
+        end
+      end
+
+      context "when compatibility is BACKWARD_TRANSITIVE" do
+        let(:compatibility) { 'BACKWARD_TRANSITIVE' }
+
+        it "performs a check with all schemas as the readers schema" do
+          check
+          expect(can_read_args.first).to eq([new_schema, second_schema])
+          expect(can_read_args.second).to eq([new_schema, old_schema])
+        end
+      end
+
+      context "when compatibility is FORWARD_TRANSITIVE" do
+        let(:compatibility) { 'FORWARD_TRANSITIVE' }
+
+        it "performs a check with all schemas as the writers schema" do
+          check
+          expect(can_read_args.first).to eq([second_schema, new_schema])
+          expect(can_read_args.second).to eq([old_schema, new_schema])
+        end
+      end
+
+      context "when compatibility is FULL_TRANSITIVE" do
+        let(:compatibility) { 'FULL_TRANSITIVE' }
+
+        it "performs a check with all schemas as the writers schema" do
+          check
+          expect(can_read_args.first).to eq([new_schema, second_schema])
+          expect(can_read_args.second).to eq([second_schema, new_schema])
+          expect(can_read_args.third).to eq([new_schema, old_schema])
+          expect(can_read_args.fourth).to eq([old_schema, new_schema])
+        end
       end
     end
   end
@@ -62,18 +124,18 @@ describe SchemaRegistry do
   describe ".compatible!" do
     let(:compatibility) { Compatibility.global }
 
-    subject { described_class.compatible!(compatibility, old_schema, new_schema) }
+    subject(:check) { described_class.compatible!(new_json, version: version) }
 
     before do
       allow(described_class).to receive(:compatible?)
-        .with(compatibility, old_schema, new_schema).and_return(compatible)
+        .with(new_json, version: version).and_return(compatible)
     end
 
     context "when schemas are compatible" do
       let(:compatible) { true }
 
       it "does not raise an error" do
-        expect { subject }.not_to raise_error
+        expect { check }.not_to raise_error
       end
     end
 
@@ -81,7 +143,7 @@ describe SchemaRegistry do
       let(:compatible) { false }
 
       it "raises IncompatibleAvroSchemaError" do
-        expect { subject }.to raise_error(SchemaRegistry::IncompatibleAvroSchemaError)
+        expect { check }.to raise_error(SchemaRegistry::IncompatibleAvroSchemaError)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+require 'simplecov'
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true


### PR DESCRIPTION
This change add support for compatibility checks against the full history of schemas for a subject.

`simplecov` was also added for code coverage.

Prime: @jturkel 