### PR TITLE
Fix Config API for subjects

### DIFF
--- a/app/api/config_api.rb
+++ b/app/api/config_api.rb
@@ -34,7 +34,7 @@ class ConfigAPI < Grape::API
   params do
     requires :subject, type: String, desc: 'Subject name'
   end
-  get '/:subject', requirements: { name: Subject::NAME_REGEXP } do
+  get '/:subject', requirements: { subject: Subject::NAME_REGEXP } do
     subject = find_subject!(params[:subject])
     { compatibility: subject.config.try(:compatibility) }
   end
@@ -44,7 +44,7 @@ class ConfigAPI < Grape::API
     requires :subject, type: String, desc: 'Subject name'
     requires :compatibility, type: String
   end
-  put '/:subject', requirements: { name: Subject::NAME_REGEXP } do
+  put '/:subject', requirements: { subject: Subject::NAME_REGEXP } do
     subject = find_subject!(params[:subject])
     subject.create_config! unless subject.config
     subject.config.update_compatibility!(params[:compatibility])

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -10,10 +10,10 @@
 
 FactoryGirl.define do
   factory :subject, aliases: [:value_subject] do
-    sequence(:name) { |n| "subject_#{n}_value" }
+    sequence(:name) { |n| "com.example.test.subject_#{n}_value" }
 
     factory :key_subject do
-      sequence(:name) { |n| "subject_#{n}_key" }
+      sequence(:name) { |n| "com.example.test.subject_#{n}_key" }
     end
   end
 


### PR DESCRIPTION
A confluence of errors here ... The subject factory did not create names containing periods and the regexp requirement was looking at the wrong parameter.

Prime: @jturkel  