### PR TITLE
Add endpoint to get schema id for subject by fingerprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,25 +43,25 @@ Get the id of the schema registered for the subject by fingerprint. The
 fingerprint may either be the hex string or the integer value produced by the
 [SHA256 fingerprint](http://avro.apache.org/docs/1.8.1/spec.html#Schema+Fingerprints).
 
-*Parameters:*
-- *subject* (_string_) - Name of the subject that the schema is registered under
-- *fingerprint* (_string_ or _integer_) - SHA256 fingerprint for the schema
+**Parameters:**
+- **subject** (_string_) - Name of the subject that the schema is registered under
+- **fingerprint** (_string_ or _integer_) - SHA256 fingerprint for the schema
 
-*Response JSON Object:*
-- *id* (_int_) - Globally unique identifier of the schema
+**Response JSON Object:**
+- **id** (_int_) - Globally unique identifier of the schema
 
-*Status Codes:*
+**Status Codes:**
 - 404 Not Found - Error Code 40403 - Schema not found
 - 500 Internal Server Error - Error code 50001 - Error in the backend datastore
 
-*Example Request:*
+**Example Request:**
 ```
 GET /subjects/test/fingerprints/90479eea876f5d6c8482b5b9e3e865ff1c0931c1bfe0adb44c41d628fd20989c HTTP/1.1
 Host: schemaregistry.example.com
 Accept: application/vnd.schemaregistry.v1+json, application/vnd.schemaregistry+json, application/json
 ```
 
-*Example response:*
+**Example response:**
 ```
 HTTP/1.1 200 OK
 Content-Type: application/vnd.schemaregistry.v1+json

--- a/README.md
+++ b/README.md
@@ -28,6 +28,47 @@ through Kafka as more ephemeral and want the flexibility to change how we host K
 In the future we may also apply per-subject permissions to the Avro schemas that
 are stored by the registry.
 
+### Extensions
+
+In addition to the Confluent Schema Registry API, this application provides an
+endpoint that can be used to determine by fingerprint if a schema is already
+registered for a subject.
+
+This endpoint provides a success response that can be cached indefinitely since
+the id for a schema will not change once it is registered for a subject.
+
+`GET /subjects/(string: subject)/fingerprints/(:fingerprint)`
+
+Get the id of the schema registered for the subject by fingerprint. The
+fingerprint may either be the hex string or the integer value produced by the
+[SHA256 fingerprint](http://avro.apache.org/docs/1.8.1/spec.html#Schema+Fingerprints).
+
+*Parameters:*
+- *subject* (_string_) - Name of the subject that the schema is registered under
+- *fingerprint* (_string_ or _integer_) - SHA256 fingerprint for the schema
+
+*Response JSON Object:*
+- *id* (_int_) - Globally unique identifier of the schema
+
+*Status Codes:*
+- 404 Not Found - Error Code 40403 - Schema not found
+- 500 Internal Server Error - Error code 50001 - Error in the backend datastore
+
+*Example Request:*
+```
+GET /subjects/test/fingerprints/90479eea876f5d6c8482b5b9e3e865ff1c0931c1bfe0adb44c41d628fd20989c HTTP/1.1
+Host: schemaregistry.example.com
+Accept: application/vnd.schemaregistry.v1+json, application/vnd.schemaregistry+json, application/json
+```
+
+*Example response:*
+```
+HTTP/1.1 200 OK
+Content-Type: application/vnd.schemaregistry.v1+json
+
+{"id":1}
+```
+
 ## Setup
 
 The application is written using Ruby 2.3.1. Start the service using the following

--- a/app/api/helpers/cache_helper.rb
+++ b/app/api/helpers/cache_helper.rb
@@ -1,0 +1,11 @@
+module Helpers
+  module CacheHelper
+
+    CACHE_CONTROL_HEADER = 'Cache-Control'.freeze
+    CACHE_CONTROL_VALUE = "public, max-age=#{Rails.configuration.x.cache_max_age}".freeze
+
+    def cache_response!
+      header(CACHE_CONTROL_HEADER, CACHE_CONTROL_VALUE) if Rails.configuration.x.allow_response_caching
+    end
+  end
+end

--- a/app/api/schema_api.rb
+++ b/app/api/schema_api.rb
@@ -9,12 +9,15 @@ class SchemaAPI < Grape::API
     server_error!
   end
 
+  helpers ::Helpers::CacheHelper
+
   desc 'Get the schema string identified by the input id'
   params do
     requires :id, type: Integer, desc: 'Schema ID'
   end
   get '/ids/:id' do
     schema = ::Schema.find(params[:id])
+    cache_response!
     { schema: schema.json }
   end
 end

--- a/app/api/subject_api.rb
+++ b/app/api/subject_api.rb
@@ -51,6 +51,29 @@ class SubjectAPI < Grape::API
       end
     end
 
+    desc 'Get the id of a specific version of the schema registered under a subject'
+    params do
+      requires :fingerprint, types: [String, Integer], desc: 'SHA256 fingerprint'
+    end
+    get '/fingerprints/:fingerprint' do
+      fingerprint = if params[:fingerprint].is_a?(Integer)
+                      params[:fingerprint].to_s(16)
+                    else
+                      params[:fingerprint]
+                    end
+
+      schema_version = SchemaVersion.select(:schema_id)
+                                    .for_subject_name(params[:name])
+                                    .for_schema_fingerprint(fingerprint).first
+
+      if schema_version
+        status 200
+        { id: schema_version.schema_id }
+      else
+        schema_not_found!
+      end
+    end
+
     desc 'Register a new schema under the specified subject'
     params do
       requires :schema, type: String, desc: 'The Avro schema string'

--- a/app/api/subject_api.rb
+++ b/app/api/subject_api.rb
@@ -18,6 +18,7 @@ class SubjectAPI < Grape::API
   end
 
   helpers ::Helpers::SchemaVersionHelper
+  helpers ::Helpers::CacheHelper
 
   desc 'Get a list of registered subjects'
   get '/' do
@@ -67,7 +68,7 @@ class SubjectAPI < Grape::API
                                     .for_schema_fingerprint(fingerprint).first
 
       if schema_version
-        status 200
+        cache_response!
         { id: schema_version.schema_id }
       else
         schema_not_found!

--- a/app/models/schema_version.rb
+++ b/app/models/schema_version.rb
@@ -22,6 +22,8 @@ class SchemaVersion < ActiveRecord::Base
         ->(subject_name) { for_subject_name(subject_name).latest }
   scope :for_schema,
         ->(schema_id) { where(schema_id: schema_id) }
+  scope :for_schema_fingerprint,
+        ->(fingerprint) { joins(:schema).where('schemas.fingerprint = ?', fingerprint) }
   scope :for_schema_json,
-        ->(json) { joins(:schema).where('schemas.fingerprint = ?', Schemas::FingerprintGenerator.call(json)) }
+        ->(json) { for_schema_fingerprint(Schemas::FingerprintGenerator.call(json)) }
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,5 +36,8 @@ module AvroSchemaRegistry
 
     config.x.disable_password = ENV['DISABLE_PASSWORD'] == 'true'
     config.x.app_password = ENV['SCHEMA_REGISTRY_PASSWORD'] || 'avro'
+
+    config.x.allow_response_caching = ENV['ALLOW_RESPONSE_CACHING'] == 'true'
+    config.x.cache_max_age = (ENV['CACHE_MAX_AGE'] || 2592000).to_i
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,6 +38,6 @@ module AvroSchemaRegistry
     config.x.app_password = ENV['SCHEMA_REGISTRY_PASSWORD'] || 'avro'
 
     config.x.allow_response_caching = ENV['ALLOW_RESPONSE_CACHING'] == 'true'
-    config.x.cache_max_age = (ENV['CACHE_MAX_AGE'] || 2592000).to_i
+    config.x.cache_max_age = (ENV['CACHE_MAX_AGE'] || 30.days).to_i
   end
 end

--- a/spec/requests/schema_api_spec.rb
+++ b/spec/requests/schema_api_spec.rb
@@ -41,12 +41,15 @@ describe SchemaAPI do
           message: 'Schema not found'
         }.to_json
       end
+      let(:action) { get("/schemas/ids/#{schema_id}") }
 
       it "returns a not found response" do
-        get("/schemas/ids/#{schema_id}")
+        action
         expect(response).to be_not_found
         expect(response.body).to be_json_eql(expected)
       end
+
+      it_behaves_like "an error that cannot be cached"
     end
   end
 end

--- a/spec/requests/schema_api_spec.rb
+++ b/spec/requests/schema_api_spec.rb
@@ -27,6 +27,10 @@ describe SchemaAPI do
         expect(response).to be_ok
         expect(response.body).to be_json_eql(expected)
       end
+
+      it_behaves_like "a cached endpoint" do
+        let(:action) { get("/schemas/ids/#{schema.id}") }
+      end
     end
 
     context "when the schema is not found" do

--- a/spec/requests/subject_api_spec.rb
+++ b/spec/requests/subject_api_spec.rb
@@ -229,6 +229,10 @@ describe SubjectAPI do
           expect(response).to be_ok
           expect(response.body).to be_json_eql(expected)
         end
+
+        it_behaves_like "a cached endpoint" do
+          let(:action) { get("/subjects/#{version.subject.name}/fingerprints/#{schema.fingerprint}") }
+        end
       end
 
       context "error cases" do

--- a/spec/requests/subject_api_spec.rb
+++ b/spec/requests/subject_api_spec.rb
@@ -243,12 +243,15 @@ describe SubjectAPI do
               message: 'Schema not found'
             }.to_json
           end
+          let(:action) { get("/subjects/#{version.subject.name}/fingerprints/#{other_fingerprint}") }
 
           it "returns a not found response" do
-            get("/subjects/#{version.subject.name}/fingerprints/#{other_fingerprint}")
+            action
             expect(response).to be_not_found
             expect(response.body).to be_json_eql(expected)
           end
+
+          it_behaves_like "an error that cannot be cached"
         end
 
         context "when the schema exists for a different subject" do
@@ -258,12 +261,15 @@ describe SubjectAPI do
               message: 'Schema not found'
             }.to_json
           end
+          let(:action) { get("/subjects/#{version.subject.name}/fingerprints/#{existing_fingerprint}") }
 
           it "returns a not found response" do
-            get("/subjects/#{version.subject.name}/fingerprints/#{existing_fingerprint}")
+            action
             expect(response).to be_not_found
             expect(response.body).to be_json_eql(expected)
           end
+
+          it_behaves_like "an error that cannot be cached"
         end
       end
     end

--- a/spec/support/contexts/cached_endpoint.rb
+++ b/spec/support/contexts/cached_endpoint.rb
@@ -21,3 +21,10 @@ shared_examples_for "a cached endpoint" do
     end
   end
 end
+
+shared_examples_for "an error that cannot be cached" do
+  it "does not allow the response to be cached" do
+    action
+    expect(response.headers['Cache-Control']).to eq('no-cache')
+  end
+end

--- a/spec/support/contexts/cached_endpoint.rb
+++ b/spec/support/contexts/cached_endpoint.rb
@@ -1,0 +1,23 @@
+shared_examples_for "a cached endpoint" do
+  context "when caching is enabled" do
+    before do
+      allow(Rails.configuration.x).to receive(:allow_response_caching).and_return(true)
+    end
+
+    it "allows the response to be cached" do
+      action
+      expect(response.headers['Cache-Control']).to eq(Helpers::CacheHelper::CACHE_CONTROL_VALUE)
+    end
+  end
+
+  context "when caching is not enabled" do
+    before do
+      allow(Rails.configuration.x).to receive(:allow_response_caching).and_return(false)
+    end
+
+    it "does not allow the response to be cached" do
+      action
+      expect(response.headers['Cache-Control']).to match(/max-age=0,/)
+    end
+  end
+end


### PR DESCRIPTION
This change adds an endpoint that supports GET requests to return the id of a schema registered for a subject based on the fingerprint of the schema.

We don't do this locally, but it is possible for the same schema to be registered under multiple subjects so it is important to restrict the lookup to the specified subject. This ensures that the schema has been registered, and compatibility checked against previous versions of that schema.

Fingerprints are supported as both integers and hex strings.

This change also adds support for returning Cache-Control headers on the two endpoints that we want to cache for durability (one of these is the new endpoint):
- GET /schemas/ids/:id
- GET /subjects/:subject/fingerprints/:fingerprint

By default, if response caching is allowed, these responses can be cached for 30 days.

Prime: @will89 