### PR TITLE
Test with Postgres 9.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: ruby
 rvm:
   - 2.3.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ services:
   - postgresql
 addons:
   postgresql: "9.6"
+before_install:
+  # Workaround for https://github.com/sickill/rainbow/issues/48
+  - gem update --system
 before_script:
   - psql -c 'create database "avro-schema-registry_test";' -U postgres
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
 services:
   - postgresql
 addons:
-  postgresql: "9.4"
+  postgresql: "9.6"
 before_script:
   - psql -c 'create database "avro-schema-registry_test";' -U postgres
 script:


### PR DESCRIPTION
I had to upgrade the build to use the Trusty container (which includes Postgres 9.6) and workaround the rubygems bug we've seen in other projects.

@tjwp - you're prime