### PR TITLE
Drop frozen error dup(lication)

### DIFF
--- a/app/api/helpers/error_helper.rb
+++ b/app/api/helpers/error_helper.rb
@@ -4,37 +4,32 @@ module Helpers
   # registry may return.
   module ErrorHelper
 
-    # Note: The requirement to dup these constants was fixed in:
-    #   https://github.com/ruby-grape/grape/pull/1336
-    # Once a version of grape is released with this fix, the
-    # dup can be dropped.
-
     def server_error!
-      error!(SchemaRegistry::Errors::SERVER_ERROR.dup, 500)
+      error!(SchemaRegistry::Errors::SERVER_ERROR, 500)
     end
 
     def subject_not_found!
-      error!(SchemaRegistry::Errors::SUBJECT_NOT_FOUND.dup, 404)
+      error!(SchemaRegistry::Errors::SUBJECT_NOT_FOUND, 404)
     end
 
     def schema_not_found!
-      error!(SchemaRegistry::Errors::SCHEMA_NOT_FOUND.dup, 404)
+      error!(SchemaRegistry::Errors::SCHEMA_NOT_FOUND, 404)
     end
 
     def version_not_found!
-      error!(SchemaRegistry::Errors::VERSION_NOT_FOUND.dup, 404)
+      error!(SchemaRegistry::Errors::VERSION_NOT_FOUND, 404)
     end
 
     def incompatible_avro_schema!
-      error!(SchemaRegistry::Errors::INCOMPATIBLE_AVRO_SCHEMA.dup, 409)
+      error!(SchemaRegistry::Errors::INCOMPATIBLE_AVRO_SCHEMA, 409)
     end
 
     def invalid_avro_schema!
-      error!(SchemaRegistry::Errors::INVALID_AVRO_SCHEMA.dup, 422)
+      error!(SchemaRegistry::Errors::INVALID_AVRO_SCHEMA, 422)
     end
 
     def invalid_compatibility_level!
-      error!(SchemaRegistry::Errors::INVALID_COMPATIBILITY_LEVEL.dup, 422)
+      error!(SchemaRegistry::Errors::INVALID_COMPATIBILITY_LEVEL, 422)
     end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,9 +27,6 @@ module AvroSchemaRegistry
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
 
-    # Do not swallow errors in after_commit/after_rollback callbacks.
-    config.active_record.raise_in_transactional_callbacks = true
-
     # Grape support
     config.paths.add(File.join('app', 'api'), glob: File.join('**', '*.rb'))
     config.autoload_paths += Dir[Rails.root.join('app', 'api', '*')]


### PR DESCRIPTION
We were still duplicating frozen error responses even though the grape fix was released a while ago.

Also remove a lingering Rails 5 deprecation.

Prime: @jturkel 