### PR TITLE
Update to salsify_rubocop v0.47.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,5 @@
 inherit_gem:
-  salsify_rubocop: conf/rubocop_rails.yml
-
-Rails/HttpPositionalArguments:
-  Enabled: true
+  salsify_rubocop: conf/rubocop_rails50.yml
 
 RSpec/NamedSubject:
   Enabled: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,7 +197,7 @@ GEM
       rubocop (>= 0.42.0)
     ruby-progressbar (1.8.1)
     ruby_dep (1.5.0)
-    salsify_rubocop (0.47.0)
+    salsify_rubocop (0.47.1)
       rubocop (~> 0.47.1)
       rubocop-rspec (~> 1.10.0)
     simplecov (0.13.0)
@@ -268,4 +268,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.13.7
+   1.14.6


### PR DESCRIPTION
This adds a new Rails 5.0 configuration that contains new custom cops to recommend dig and require use of ApplicationRecord.

Prime: @jturkel 