### PR TITLE
Introduce Fingerprint v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # avro-schema-registry
 
+## v0.6.0 (unreleased)
+- Introduce fingerprint2 based on `avro-resolution_canonical_form`.
+  This is a compatibility breaking change and requires a sequence of upgrade steps.
+- Fix fingerprint endpoint when using an integer fingerprint.
+
 ## v0.5.0
 - Fix Config API for subjects.
 - Add endpoint to get schema id by fingerprint.

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ ruby '2.3.3'
 source 'https://rubygems.org'
 
 gem 'avro-salsify-fork', '1.9.0.5', require: 'avro'
+
+gem 'avro-resolution_canonical_form', '0.1.0.rc0'
 gem 'grape'
 gem 'ice_nine', require: 'ice_nine/core_ext/object'
 gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,8 @@ GEM
     ast (2.3.0)
     avro (1.8.1)
       multi_json
+    avro-resolution_canonical_form (0.1.0.rc0)
+      avro-salsify-fork (>= 1.9.0.5)
     avro-salsify-fork (1.9.0.5)
       multi_json
     avro_turf (0.8.0)
@@ -241,6 +243,7 @@ PLATFORMS
 
 DEPENDENCIES
   annotate
+  avro-resolution_canonical_form (= 0.1.0.rc0)
   avro-salsify-fork (= 1.9.0.5)
   avro_turf (>= 0.8.0)
   bugsnag

--- a/README.md
+++ b/README.md
@@ -12,6 +12,27 @@ Schema versions stored by the service are assigned an id. These ids can be
 embedded in messages published to Kafka avoiding the need to send the full
 schema with each message.
 
+## Upgrading to v0.6.0
+
+There is a compatibility break when upgrading to v0.6.0 due to the way that
+fingerprints are generated. Prior to v0.6.0 fingerprints were generated based
+on the Parsing Canonical Form for Avro schemas. This does not take into account
+attributes such as `default` that are used during schema resolution and for
+compatibility checking. The new fingerprint is based on [avro-resolution_canonical_form](https://github.com/salsify/avro-resolution_canonical_form).
+
+To upgrade:
+# Set `FINGERPRINT_VERSION=1` and `DISABLE_SCHEMA_REGISTRATION=true` in the
+  environment for the application.
+# Deploy v0.6.0 and run migrations to create and populate the new `fingerprint2`
+  column.
+# If NOT using the fingerprint endpoint move to the final step.
+# Set `FINGERPRINT_VERSION=all`, unset `DISABLE_SCHEMA_REGISTRATION`, and restart the application.
+# Update all clients to use the v2 fingerprint.
+# Set `FINGERPRINT_VERSION=2` and unset `DISABLE_SCHEMA_REGISTRATION` (if still set) and
+  restart the application.
+
+At some point in the future the original `fingerprint` column will be removed.
+
 ## Overview
 
 This application provides the same API as the Confluent

--- a/README.md
+++ b/README.md
@@ -21,14 +21,15 @@ attributes such as `default` that are used during schema resolution and for
 compatibility checking. The new fingerprint is based on [avro-resolution_canonical_form](https://github.com/salsify/avro-resolution_canonical_form).
 
 To upgrade:
-# Set `FINGERPRINT_VERSION=1` and `DISABLE_SCHEMA_REGISTRATION=true` in the
+
+1. Set `FINGERPRINT_VERSION=1` and `DISABLE_SCHEMA_REGISTRATION=true` in the
   environment for the application, and restart the application.
-# Deploy v0.6.0 and run migrations to create and populate the new `fingerprint2`
+2. Deploy v0.6.0 and run migrations to create and populate the new `fingerprint2`
   column.
-# If NOT using the fingerprint endpoint move to the final step.
-# Set `FINGERPRINT_VERSION=all`, unset `DISABLE_SCHEMA_REGISTRATION`, and restart the application.
-# Update all clients to use the v2 fingerprint.
-# Set `FINGERPRINT_VERSION=2` and unset `DISABLE_SCHEMA_REGISTRATION` (if still set) and
+3. If NOT using the fingerprint endpoint, move to the final step.
+4. Set `FINGERPRINT_VERSION=all`, unset `DISABLE_SCHEMA_REGISTRATION`, and restart the application.
+5. Update all clients to use the v2 fingerprint.
+6. Set `FINGERPRINT_VERSION=2` and unset `DISABLE_SCHEMA_REGISTRATION` (if still set) and
   restart the application.
 
 At some point in the future the original `fingerprint` column will be removed.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ compatibility checking. The new fingerprint is based on [avro-resolution_canonic
 
 To upgrade:
 # Set `FINGERPRINT_VERSION=1` and `DISABLE_SCHEMA_REGISTRATION=true` in the
-  environment for the application.
+  environment for the application, and restart the application.
 # Deploy v0.6.0 and run migrations to create and populate the new `fingerprint2`
   column.
 # If NOT using the fingerprint endpoint move to the final step.

--- a/app/api/subject_api.rb
+++ b/app/api/subject_api.rb
@@ -1,6 +1,8 @@
 class SubjectAPI < Grape::API
   include BaseAPI
 
+  INTEGER_FINGERPRINT_REGEXP = /^[0-9]+$/
+
   rescue_from ActiveRecord::RecordNotFound do
     subject_not_found!
   end
@@ -57,7 +59,7 @@ class SubjectAPI < Grape::API
       requires :fingerprint, types: [String, Integer], desc: 'SHA256 fingerprint'
     end
     get '/fingerprints/:fingerprint' do
-      fingerprint = if /^[0-9]+$/ =~ params[:fingerprint]
+      fingerprint = if INTEGER_FINGERPRINT_REGEXP =~ params[:fingerprint]
                       params[:fingerprint].to_i.to_s(16)
                     else
                       params[:fingerprint]

--- a/app/models/schema.rb
+++ b/app/models/schema.rb
@@ -2,24 +2,40 @@
 #
 # Table name: schemas
 #
-#  id          :integer          not null, primary key
-#  fingerprint :string           not null
-#  json        :text             not null
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
+#  id           :integer          not null, primary key
+#  fingerprint  :string           not null
+#  json         :text             not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  fingerprint2 :string
 #
 
 class Schema < ApplicationRecord
   include ImmutableModel
 
-  before_save :generate_fingerprint
+  before_save :generate_fingerprints
 
   has_many :versions, class_name: 'SchemaVersion'
   has_many :subjects, through: :versions
 
+  def self.existing_schema(json)
+    if Schemas::FingerprintGenerator.include_v2?
+      schema = find_by(fingerprint2: Schemas::FingerprintGenerator.generate_v2(json))
+    end
+    if Schemas::FingerprintGenerator.include_v1? && schema.nil?
+      schema = find_by(fingerprint: Schemas::FingerprintGenerator.generate_v1(json))
+    end
+
+    schema
+  end
+
   private
 
-  def generate_fingerprint
-    self.fingerprint = Schemas::FingerprintGenerator.call(json)
+  def generate_fingerprints
+    self.fingerprint = Schemas::FingerprintGenerator.generate_v1(json)
+
+    if Schemas::FingerprintGenerator.include_v2?
+      self.fingerprint2 = Schemas::FingerprintGenerator.generate_v2(json)
+    end
   end
 end

--- a/app/models/schema.rb
+++ b/app/models/schema.rb
@@ -18,7 +18,7 @@ class Schema < ApplicationRecord
   has_many :versions, class_name: 'SchemaVersion'
   has_many :subjects, through: :versions
 
-  scope :with_fingerprints, -> (fingerprint, fingerprint2 = nil) do
+  scope :with_fingerprints, ->(fingerprint, fingerprint2 = nil) do
     fingerprint2 ||= fingerprint
     case Rails.configuration.x.fingerprint_version
     when '1'

--- a/app/models/schema.rb
+++ b/app/models/schema.rb
@@ -18,15 +18,6 @@ class Schema < ApplicationRecord
   has_many :versions, class_name: 'SchemaVersion'
   has_many :subjects, through: :versions
 
-  scope :with_json, ->(json) do
-    with_fingerprints(Schemas::FingerprintGenerator.include_v1? ? Schemas::FingerprintGenerator.generate_v1(json) : nil,
-                      Schemas::FingerprintGenerator.include_v2? ? Schemas::FingerprintGenerator.generate_v2(json) : nil)
-  end
-
-  scope :with_fingerprint, ->(fingerprint) do
-    with_fingerprints(fingerprint)
-  end
-
   scope :with_fingerprints, -> (fingerprint, fingerprint2 = nil) do
     fingerprint2 ||= fingerprint
     case Rails.configuration.x.fingerprint_version
@@ -37,6 +28,15 @@ class Schema < ApplicationRecord
     else
       where('schemas.fingerprint = ? OR schemas.fingerprint2 = ?', fingerprint, fingerprint2)
     end
+  end
+
+  scope :with_fingerprint, ->(fingerprint) do
+    with_fingerprints(fingerprint)
+  end
+
+  scope :with_json, ->(json) do
+    with_fingerprints(Schemas::FingerprintGenerator.include_v1? ? Schemas::FingerprintGenerator.generate_v1(json) : nil,
+                      Schemas::FingerprintGenerator.include_v2? ? Schemas::FingerprintGenerator.generate_v2(json) : nil)
   end
 
   def self.existing_schema(json)

--- a/app/models/schema.rb
+++ b/app/models/schema.rb
@@ -18,6 +18,27 @@ class Schema < ApplicationRecord
   has_many :versions, class_name: 'SchemaVersion'
   has_many :subjects, through: :versions
 
+  scope :with_json, ->(json) do
+    with_fingerprints(Schemas::FingerprintGenerator.include_v1? ? Schemas::FingerprintGenerator.generate_v1(json) : nil,
+                      Schemas::FingerprintGenerator.include_v2? ? Schemas::FingerprintGenerator.generate_v2(json) : nil)
+  end
+
+  scope :with_fingerprint, ->(fingerprint) do
+    with_fingerprints(fingerprint)
+  end
+
+  scope :with_fingerprints, -> (fingerprint, fingerprint2 = nil) do
+    fingerprint2 ||= fingerprint
+    case Rails.configuration.x.fingerprint_version
+    when '1'
+      where('schemas.fingerprint = ?', fingerprint)
+    when '2'
+      where('schemas.fingerprint2 = ?', fingerprint2)
+    else
+      where('schemas.fingerprint = ? OR schemas.fingerprint2 = ?', fingerprint, fingerprint2)
+    end
+  end
+
   def self.existing_schema(json)
     if Schemas::FingerprintGenerator.include_v2?
       schema = find_by(fingerprint2: Schemas::FingerprintGenerator.generate_v2(json))

--- a/app/models/schema_version.rb
+++ b/app/models/schema_version.rb
@@ -22,28 +22,6 @@ class SchemaVersion < ApplicationRecord
         ->(subject_name) { for_subject_name(subject_name).latest }
   scope :for_schema,
         ->(schema_id) { where(schema_id: schema_id) }
-  scope :for_schema_fingerprint,
-        ->(fingerprint) do
-          case Rails.configuration.x.fingerprint_version
-          when '1'
-            joins(:schema).where('schemas.fingerprint = ?', fingerprint)
-          when '2'
-            joins(:schema).where('schemas.fingerprint2 = ?', fingerprint)
-          else
-            joins(:schema).where('schemas.fingerprint = ? OR schemas.fingerprint2 = ?', fingerprint, fingerprint)
-          end
-        end
-  scope :for_schema_json,
-        ->(json) do
-          case Rails.configuration.x.fingerprint_version
-          when '1'
-            joins(:schema).where('schemas.fingerprint = ?', Schemas::FingerprintGenerator.generate_v1(json))
-          when '2'
-            joins(:schema).where('schemas.fingerprint2 = ?', Schemas::FingerprintGenerator.generate_v2(json))
-          else
-            joins(:schema).where('schemas.fingerprint = ? OR schemas.fingerprint2 = ?',
-                                 Schema::FingerprintGenerator.generate_v1(json),
-                                 Schema::FingerprintGenerator.generate_v2(json))
-          end
-        end
+  scope :for_schema_fingerprint, ->(fingerprint) { joins(:schema).merge(Schema.with_fingerprint(fingerprint)) }
+  scope :for_schema_json, ->(json) { joins(:schema).merge(Schema.with_json(json)) }
 end

--- a/app/models/schemas/fingerprint_generator.rb
+++ b/app/models/schemas/fingerprint_generator.rb
@@ -3,8 +3,23 @@ module Schemas
   # Avro JSON schema
   module FingerprintGenerator
 
-    def self.call(json)
+    V1_VERSIONS = %w(1 all).freeze
+    V2_VERSIONS = %w(2 all).freeze
+
+    def self.generate_v1(json)
       Schemas::Parse.call(json).sha256_fingerprint.to_s(16)
+    end
+
+    def self.generate_v2(json)
+      Schemas::Parse.call(json).sha256_resolution_fingerprint.to_s(16)
+    end
+
+    def self.include_v2?
+      V2_VERSIONS.include?(Rails.configuration.x.fingerprint_version)
+    end
+
+    def self.include_v1?
+      V1_VERSIONS.include?(Rails.configuration.x.fingerprint_version)
     end
   end
 end

--- a/app/models/schemas/fingerprint_generator.rb
+++ b/app/models/schemas/fingerprint_generator.rb
@@ -3,8 +3,16 @@ module Schemas
   # Avro JSON schema
   module FingerprintGenerator
 
-    V1_VERSIONS = %w(1 all).freeze
-    V2_VERSIONS = %w(2 all).freeze
+    VALID_FINGERPRINT_VERSIONS = Set.new(%w(1 2 all)).deep_freeze
+
+    V1_VERSIONS = Set.new(%w(1 all)).deep_freeze
+    V2_VERSIONS = Set.new(%w(2 all)).deep_freeze
+
+    def self.valid_fingerprint_version!
+      unless VALID_FINGERPRINT_VERSIONS.include?(Rails.configuration.x.fingerprint_version)
+        raise "Invalid fingerprint version: #{Rails.configuration.x.fingerprint_version.inspect}"
+      end
+    end
 
     def self.generate_v1(json)
       Schemas::Parse.call(json).sha256_fingerprint.to_s(16)

--- a/app/models/schemas/register_new_version.rb
+++ b/app/models/schemas/register_new_version.rb
@@ -36,12 +36,8 @@ module Schemas
 
     private
 
-    def fingerprint
-      @fingerprint ||= Schemas::FingerprintGenerator.call(json)
-    end
-
     def register_new_version
-      self.schema = Schema.find_by(fingerprint: fingerprint)
+      self.schema = Schema.existing_schema(json)
 
       if schema
         create_new_version

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,5 +36,8 @@ module AvroSchemaRegistry
 
     config.x.allow_response_caching = ENV['ALLOW_RESPONSE_CACHING'] == 'true'
     config.x.cache_max_age = (ENV['CACHE_MAX_AGE'] || 30.days).to_i
+
+    config.x.fingerprint_version = (ENV['FINGERPRINT_VERSION'] || '1').downcase
+    config.x.disable_schema_registration = ENV['DISABLE_SCHEMA_REGISTRATION'] == 'true'
   end
 end

--- a/config/initializers/fingerprint_version.rb
+++ b/config/initializers/fingerprint_version.rb
@@ -1,0 +1,1 @@
+Schemas::FingerprintGenerator.valid_fingerprint_version!

--- a/db/migrate/20170310182013_add_fingerprint2_to_schemas.rb
+++ b/db/migrate/20170310182013_add_fingerprint2_to_schemas.rb
@@ -1,0 +1,9 @@
+class AddFingerprint2ToSchemas < ActiveRecord::Migration[5.0]
+  def change
+    add_column(:schemas, :fingerprint2, :string, null: true)
+    add_index(:schemas, :fingerprint2, unique: true)
+
+    remove_index(:schemas, :fingerprint)
+    add_index(:schemas, :fingerprint, unique: false)
+  end
+end

--- a/db/migrate/20170310200653_populate_fingerprint2.rb
+++ b/db/migrate/20170310200653_populate_fingerprint2.rb
@@ -1,0 +1,17 @@
+class PopulateFingerprint2 < ActiveRecord::Migration[5.0]
+
+  class Schema < ApplicationRecord
+  end
+
+  def up
+    Schema.find_each(batch_size: 100) do |schema|
+      schema.update_attribute(
+        :fingerprint2,
+        Schemas::FingerprintGenerator.generate_v2(schema.json))
+    end
+  end
+
+  def down
+    Schema.update_all(fingerprint2: nil)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160416174131) do
+ActiveRecord::Schema.define(version: 20170310200653) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,11 +31,13 @@ ActiveRecord::Schema.define(version: 20160416174131) do
   end
 
   create_table "schemas", id: :bigserial, force: :cascade do |t|
-    t.string   "fingerprint", null: false
-    t.text     "json",        null: false
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
-    t.index ["fingerprint"], name: "index_schemas_on_fingerprint", unique: true, using: :btree
+    t.string   "fingerprint",  null: false
+    t.text     "json",         null: false
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
+    t.string   "fingerprint2"
+    t.index ["fingerprint"], name: "index_schemas_on_fingerprint", using: :btree
+    t.index ["fingerprint2"], name: "index_schemas_on_fingerprint2", unique: true, using: :btree
   end
 
   create_table "subjects", id: :bigserial, force: :cascade do |t|

--- a/spec/factories/configs.rb
+++ b/spec/factories/configs.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: configs
+#
+#  id            :integer          not null, primary key
+#  compatibility :string
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  subject_id    :integer
+#
+
 FactoryGirl.define do
   factory :config do
     subject

--- a/spec/factories/schema_versions.rb
+++ b/spec/factories/schema_versions.rb
@@ -3,7 +3,7 @@
 # Table name: schema_versions
 #
 #  id         :integer          not null, primary key
-#  version    :integer          default("1")
+#  version    :integer          default(1)
 #  subject_id :integer          not null
 #  schema_id  :integer          not null
 #

--- a/spec/factories/schemas.rb
+++ b/spec/factories/schemas.rb
@@ -22,4 +22,16 @@ FactoryGirl.define do
       }.to_json
     end
   end
+
+  factory :schema_without_default, class: Schema do
+    sequence(:json) do |n|
+      {
+        type: :record,
+        name: "rec#{n}",
+        fields: [
+          { name: "field#{n}", type: :int }
+        ]
+      }.to_json
+    end
+  end
 end

--- a/spec/factories/schemas.rb
+++ b/spec/factories/schemas.rb
@@ -2,11 +2,12 @@
 #
 # Table name: schemas
 #
-#  id          :integer          not null, primary key
-#  fingerprint :string           not null
-#  json        :text             not null
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
+#  id           :integer          not null, primary key
+#  fingerprint  :string           not null
+#  json         :text             not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  fingerprint2 :string
 #
 
 FactoryGirl.define do
@@ -16,7 +17,7 @@ FactoryGirl.define do
         type: :record,
         name: "rec#{n}",
         fields: [
-          { name: "field#{n}", type: :string }
+          { name: "field#{n}", type: :string, default: '' }
         ]
       }.to_json
     end

--- a/spec/models/schema_spec.rb
+++ b/spec/models/schema_spec.rb
@@ -7,7 +7,7 @@ describe Schema do
     let(:schema) { build(:schema) }
 
     before do
-      schema.save
+      schema.save!
     end
 
     context "when fingerprint_version is '1'" do
@@ -55,9 +55,9 @@ describe Schema do
     before do
       # rubocop:disable Rails/SkipsModelValidations
       schema1.update_columns(fingerprint: fingerprint_v1,
-                                fingerprint2: Schemas::FingerprintGenerator.generate_v2(schema1.json))
+                             fingerprint2: Schemas::FingerprintGenerator.generate_v2(schema1.json))
       schema2.update_columns(fingerprint: Schemas::FingerprintGenerator.generate_v1(schema2.json),
-                               fingerprint2: fingerprint_v2)
+                             fingerprint2: fingerprint_v2)
       # rubocop:enable Rails/SkipsModelValidations
     end
 

--- a/spec/models/schema_spec.rb
+++ b/spec/models/schema_spec.rb
@@ -1,0 +1,118 @@
+describe Schema do
+  before do
+    allow(Rails.configuration.x).to receive(:fingerprint_version).and_return(fingerprint_version)
+  end
+
+  describe '#save' do
+    let(:schema) { build(:schema) }
+
+    before do
+      schema.save
+    end
+
+    context "when fingerprint_version is '1'" do
+      let(:fingerprint_version) { '1' }
+
+      it "sets fingerprint" do
+        expect(schema.fingerprint).to be_present
+      end
+
+      it "does not set fingerprint2" do
+        expect(schema.fingerprint2).to be_nil
+      end
+    end
+
+    shared_examples_for "it sets both fingerprints" do
+      it "sets fingerprint" do
+        expect(schema.fingerprint).to be_present
+      end
+
+      it "sets fingerprint2" do
+        expect(schema.fingerprint2).to be_present
+      end
+    end
+
+    context "when fingerprint_version is '2'" do
+      let(:fingerprint_version) { '2' }
+
+      it_behaves_like "it sets both fingerprints"
+    end
+
+    context "when fingerprint_version is 'all'" do
+      let(:fingerprint_version) { '2' }
+
+      it_behaves_like "it sets both fingerprints"
+    end
+  end
+
+  describe "self.existing_schema" do
+    let(:schema1) { create(:schema) }
+    let(:schema2) { create(:schema) }
+    let(:json) { build(:schema).json }
+    let(:fingerprint_v1) { Schemas::FingerprintGenerator.generate_v1(json) }
+    let(:fingerprint_v2) { Schemas::FingerprintGenerator.generate_v2(json) }
+
+    before do
+      # rubocop:disable Rails/SkipsModelValidations
+      schema1.update_columns(fingerprint: fingerprint_v1,
+                                fingerprint2: Schemas::FingerprintGenerator.generate_v2(schema1.json))
+      schema2.update_columns(fingerprint: Schemas::FingerprintGenerator.generate_v1(schema2.json),
+                               fingerprint2: fingerprint_v2)
+      # rubocop:enable Rails/SkipsModelValidations
+    end
+
+    context "when fingerprint_version is '1'" do
+      let(:fingerprint_version) { '1' }
+
+      it "finds the existing schema by fingerprint v1" do
+        expect(Schema.existing_schema(json)).to eq(schema1)
+      end
+
+      context "when there is no schema matching fingerprint v1" do
+        before do
+          ActiveRecord::Base.connection.execute("DELETE FROM schemas where id = #{schema1.id}")
+        end
+
+        it "returns nil" do
+          expect(Schema.existing_schema(json)).to be_nil
+        end
+      end
+    end
+
+    context "when fingerprint_version is '2'" do
+      let(:fingerprint_version) { '2' }
+
+      it "finds the existing schema by fingerprint v2" do
+        expect(Schema.existing_schema(json)).to eq(schema2)
+      end
+
+      context "when there is no schema matching fingerprint v2" do
+        before do
+          ActiveRecord::Base.connection.execute("DELETE FROM schemas where id = #{schema2.id}")
+        end
+
+        it "returns nil" do
+          expect(Schema.existing_schema(json)).to be_nil
+        end
+      end
+    end
+
+    context "when fingerprint_version is 'all'" do
+      let(:fingerprint_version) { 'all' }
+
+      it "finds the existing schema by fingerprint v2" do
+        expect(Schema.existing_schema(json)).to eq(schema2)
+      end
+
+      context "when there is no schema matching fingerprint v2" do
+        before do
+          ActiveRecord::Base.connection.execute("DELETE FROM schemas where id = #{schema2.id}")
+        end
+
+        it "finds the existing schema by fingerprint v1" do
+          expect(Schema.existing_schema(json)).to eq(schema1)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This modifies the schema registry to use a fingerprint based on [avro-resolution_canonical_form](https://github.com/salsify/avro-resolution_canonical_form) and supports a series of steps to migrate to the new fingerprint.

Prime: @jturkel 