### PR TITLE
Allow level to be specified when checking compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avro-schema-registry
 
+## v0.7.0
+- Allow the compatibility level to be specified in the Compatibility API.
+
 ## v0.6.2
 - Update `cache_all_requests` task to use the resolution fingerprint.
 

--- a/README.md
+++ b/README.md
@@ -50,11 +50,15 @@ through Kafka as more ephemeral and want the flexibility to change how we host K
 In the future we may also apply per-subject permissions to the Avro schemas that
 are stored by the registry.
 
-### Extensions
+## Extensions
 
-In addition to the Confluent Schema Registry API, this application provides an
-endpoint that can be used to determine by fingerprint if a schema is already
-registered for a subject.
+In addition to the Confluent Schema Registry API, this application provides some
+extensions.
+
+### Schema ID by Fingerprint
+
+There is an endpoint that can be used to determine by
+fingerprint if a schema is already registered for a subject.
 
 This endpoint provides a success response that can be cached indefinitely since
 the id for a schema will not change once it is registered for a subject.
@@ -89,6 +93,27 @@ HTTP/1.1 200 OK
 Content-Type: application/vnd.schemaregistry.v1+json
 
 {"id":1}
+```
+
+### Test Compatibility with a Specified Level
+
+The Compatibility API is extended to support a `with_compatibility` parameter
+that controls the level used for the compatibility check against the specified
+schema version.
+
+When `with_compatibility` is specified, it overrides any configuration for the
+subject and the global configuration.
+
+**Example Request:**
+```
+POST /subjects/test/versions/latest HTTP/1.1
+Host: schemaregistry.example.com
+Accept: application/vnd.schemaregistry.v1+json, application/vnd.schemaregistry+json, application/json
+
+{
+  "schema": "{ ... }",
+  "with_compatibility": "BACKWARD"
+}
 ```
 
 ## Setup

--- a/app/api/compatibility_api.rb
+++ b/app/api/compatibility_api.rb
@@ -7,6 +7,14 @@ class CompatibilityAPI < Grape::API
     invalid_avro_schema!
   end
 
+  rescue_from Grape::Exceptions::ValidationErrors do |e|
+    if e.errors.keys == [%w(with_compatibility)]
+      invalid_compatibility_level!
+    else
+      error!({ message: e.message }, 422)
+    end
+  end
+
   rescue_from :all do
     server_error!
   end
@@ -18,11 +26,17 @@ class CompatibilityAPI < Grape::API
     requires :version_id, types: [Integer, String],
              desc: 'Version of the schema registered under the subject'
     requires :schema, type: String, desc: 'New Avro schema to compare against'
+    optional :with_compatibility, type: String, desc: 'The compatibility level to test',
+             values: Compatibility::Constants::VALUES.to_a
   end
   post '/subjects/:subject/versions/:version_id', requirements: { subject: Subject::NAME_REGEXP } do
     with_schema_version(params[:subject], params[:version_id]) do |schema_version|
       status 200
-      { is_compatible: SchemaRegistry.compatible?(params[:schema], version: schema_version) }
+      {
+        is_compatible: SchemaRegistry.compatible?(params[:schema],
+                                                  version: schema_version,
+                                                  compatibility: params[:with_compatibility])
+      }
     end
   end
 end

--- a/app/models/schema_registry.rb
+++ b/app/models/schema_registry.rb
@@ -4,8 +4,8 @@ module SchemaRegistry
 
   extend self
 
-  def compatible?(new_json, version:)
-    compatibility = version.subject.config.try(:compatibility) || Compatibility.global
+  def compatible?(new_json, version:, compatibility: nil)
+    compatibility ||= version.subject.config.try(:compatibility) || Compatibility.global
 
     if Compatibility::Constants::TRANSITIVE_VALUES.include?(compatibility)
       check_all_versions(compatibility, new_json, version.subject)

--- a/spec/schema_registry_spec.rb
+++ b/spec/schema_registry_spec.rb
@@ -4,6 +4,7 @@ describe SchemaRegistry do
   let(:new_json) { build(:schema).json }
   let(:old_schema) { Avro::Schema.parse(version.schema.json) }
   let(:new_schema) { Avro::Schema.parse(new_json) }
+  let(:compatibility) { 'FULL_TRANSITIVE' }
 
   before do
     create(:config, subject_id: version.subject_id, compatibility: compatibility) if compatibility
@@ -14,6 +15,11 @@ describe SchemaRegistry do
 
     before do
       allow(Avro::SchemaCompatibility).to receive(:can_read?).and_call_original
+    end
+
+    it "allows compatibility to be specified" do
+      described_class.compatible?(new_json, version: version, compatibility: 'BACKWARD')
+      expect(Avro::SchemaCompatibility).to have_received(:can_read?).with(new_schema, old_schema)
     end
 
     context "when compatibility is nil" do


### PR DESCRIPTION
I called the new parameter `with_compatibility` because I was thinking that we may eventually support `with_compatibility` and `after_compatibility` parameters when registering a new schema, so set the compatibility to use during registration, and after the new schema is registered (in a single transaction).

Prime: @jturkel 