### PR TITLE
Reverse BACKWARD and FORWARD compatibility definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## v0.8.1
 - Reverse the definition of BACKWARD and FORWARD compatibility levels.
   Previous releases had these backwards.
+  Note: The compatibility level is NOT changed for existing configs in the
+  database. Current compatibility levels should be reviewed to ensure that the
+  expectation is consistent with the description here:
+  http://docs.confluent.io/3.2.0/avro.html#schema-evolution.
 
 ## v0.8.0
 - Allow the compatibility level to use while registering a schema to be specified,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # avro-schema-registry
 
+## v0.8.1
+- Reverse the definition of BACKWARD and FORWARD compatibility levels.
+  Previous releases had these backwards.
+
 ## v0.8.0
 - Allow the compatibility level to use while registering a schema to be specified,
   and a compatibility level to set for the subject after registration.

--- a/app/models/schema_registry.rb
+++ b/app/models/schema_registry.rb
@@ -41,9 +41,9 @@ module SchemaRegistry
     when Compatibility::Constants::NONE
       true
     when Compatibility::Constants::BACKWARD
-      check(old_schema, new_schema)
-    when Compatibility::Constants::FORWARD
       check(new_schema, old_schema)
+    when Compatibility::Constants::FORWARD
+      check(old_schema, new_schema)
     when Compatibility::Constants::FULL, Compatibility::Constants::BOTH
       check(old_schema, new_schema) && check(new_schema, old_schema)
     end
@@ -55,9 +55,9 @@ module SchemaRegistry
 
     case compatibility
     when Compatibility::Constants::BACKWARD_TRANSITIVE
-      json_schemas.all? { |json| check(Schemas::Parse.call(json), new_schema) }
-    when Compatibility::Constants::FORWARD_TRANSITIVE
       json_schemas.all? { |json| check(new_schema, Schemas::Parse.call(json)) }
+    when Compatibility::Constants::FORWARD_TRANSITIVE
+      json_schemas.all? { |json| check(Schemas::Parse.call(json), new_schema) }
     when Compatibility::Constants::FULL_TRANSITIVE
       json_schemas.all? do |json|
         old_schema = Schemas::Parse.call(json)


### PR DESCRIPTION
Reading through this (which is a good overview doc): http://docs.confluent.io/3.2.0/avro.html

And re-confirmed here: http://docs.confluent.io/1.0/schema-registry/docs/api.html#compatibility

I realized that the definitions of BACKWARD and FORWARD compatibility used in this app were reversed.

I've also increased test coverage with some example to show the updated definition match expectations about which can read another schema.

I think the avrolution gem also needs to be updated.

Prime: @jturkel 