### PR TITLE
Support dual deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avro-schema-registry
 
+## v0.9.1
+- Support dual deploys.
+
 ## v0.9.0
 - Add read-only mode for the application.
 

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ end
 group :development do
   gem 'annotate'
   gem 'avro_turf', '>= 0.8.0', require: false
-  gem 'heroku_rails_deploy', '>= 0.2.2', require: false
+  gem 'heroku_rails_deploy', '0.4.0.rc0', require: false
   gem 'overcommit'
   gem 'spring'
   gem 'spring-commands-rspec'

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ end
 group :development do
   gem 'annotate'
   gem 'avro_turf', '>= 0.8.0', require: false
-  gem 'heroku_rails_deploy', '0.4.0.rc0', require: false
+  gem 'heroku_rails_deploy', '>= 0.4.0', require: false
   gem 'overcommit'
   gem 'spring'
   gem 'spring-commands-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,8 @@ GEM
       rack-accept
       virtus (>= 1.0.0)
     hashie (3.5.4)
-    heroku_rails_deploy (0.2.2)
+    heroku_rails_deploy (0.4.0.rc0)
+      private_attr
       rails
     i18n (0.8.1)
     ice_nine (0.11.2)
@@ -250,7 +251,7 @@ DEPENDENCIES
   bugsnag
   factory_girl_rails
   grape
-  heroku_rails_deploy (>= 0.2.2)
+  heroku_rails_deploy (= 0.4.0.rc0)
   ice_nine
   json_spec
   newrelic_rpm

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,7 @@ GEM
       rack-accept
       virtus (>= 1.0.0)
     hashie (3.5.4)
-    heroku_rails_deploy (0.4.0.rc0)
+    heroku_rails_deploy (0.4.0)
       private_attr
       rails
     i18n (0.8.1)
@@ -251,7 +251,7 @@ DEPENDENCIES
   bugsnag
   factory_girl_rails
   grape
-  heroku_rails_deploy (= 0.4.0.rc0)
+  heroku_rails_deploy (>= 0.4.0)
   ice_nine
   json_spec
   newrelic_rpm

--- a/bin/deploy
+++ b/bin/deploy
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require_relative '../config/boot'
-require 'heroku_rails_deploy'
+require_relative '../lib/dual_heroku_rails_deploy'
 
 root_dir = File.absolute_path("#{__dir__}/..")
-HerokuRailsDeploy.deploy(root_dir, ARGV)
+DualHerokuRailsDeploy.deploy(root_dir, ARGV)

--- a/config/heroku.yml
+++ b/config/heroku.yml
@@ -1,3 +1,4 @@
 ---
 production: schema-registry-prod
 staging: schema-registry-staging
+compatibility: schema-registry-compatibility

--- a/lib/dual_heroku_rails_deploy.rb
+++ b/lib/dual_heroku_rails_deploy.rb
@@ -1,0 +1,16 @@
+require 'heroku_rails_deploy/deployer'
+
+module DualHerokuRailsDeploy
+
+  COMPATIBILITY_ENVIRONMENT_ARGS = %w(-e compatibility).map(&:freeze).freeze
+
+  def self.deploy(root_dir, args)
+    config_file = File.join(root_dir, 'config', 'heroku.yml')
+    deploy = HerokuRailsDeploy::Deployer.new(config_file, args)
+    deploy.run
+
+    if deploy.production?
+      HerokuRailsDeploy::Deployer.new(config_file, COMPATIBILITY_ENVIRONMENT_ARGS).run
+    end
+  end
+end


### PR DESCRIPTION
Made a quick attempt at deploying to multiple environments.

The approach is to replace `HerokuRailsDeploy.deploy` and call `HerokuRailsDeploy::Deployer` directly.

The changes to `heroku_rails_deploy` to support this are here: https://github.com/salsify/heroku_rails_deploy/pull/5

Prime: @jturkel 