### PR TITLE
Change the default fingerprint version to 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # avro-schema-registry
 
 ## v0.11.0
-- Change the default fingerprint version to '2'.
+- Change the default fingerprint version to '2'. Set `FINGERPRINT_VERSION=1`
+  before upgrading if you have not migrated to fingerprint version 2.
 
 ## v0.10.0
 - Use `avro-patches` instead of `avro-salsify-fork`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avro-schema-registry
 
+## v0.11.0
+- Change the default fingerprint version to '2'.
+
 ## v0.10.0
 - Use `avro-patches` instead of `avro-salsify-fork`.
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ Schema versions stored by the service are assigned an id. These ids can be
 embedded in messages published to Kafka avoiding the need to send the full
 schema with each message.
 
+## Upgrading to v0.11.0
+
+v0.11.0 changes the default fingerprint version to 2. Set `FINGERPRINT_VERSION=1`
+before upgrading if you have not migrated to fingerprint version 2.
+
 ## Upgrading to v0.6.0
 
 There is a compatibility break when upgrading to v0.6.0 due to the way that

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,7 +37,7 @@ module AvroSchemaRegistry
     config.x.allow_response_caching = ENV['ALLOW_RESPONSE_CACHING'] == 'true'
     config.x.cache_max_age = (ENV['CACHE_MAX_AGE'] || 30.days).to_i
 
-    config.x.fingerprint_version = (ENV['FINGERPRINT_VERSION'] || '1').downcase
+    config.x.fingerprint_version = (ENV['FINGERPRINT_VERSION'] || '2').downcase
     config.x.disable_schema_registration = ENV['DISABLE_SCHEMA_REGISTRATION'] == 'true'
 
     config.x.read_only_mode = ENV['READ_ONLY_MODE'] == 'true'


### PR DESCRIPTION
This change probably should have been made a while ago so that new deployments of the registry uses a sensible default.

The original fingerprint support has not been removed.

Prime: @jturkel 