### PR TITLE
Adding schema id to subject version lookup response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # Ignore bundler config.
 /.bundle
+.env
 
 # Ignore local configuration
 /.envrc

--- a/app/api/subject_api.rb
+++ b/app/api/subject_api.rb
@@ -49,7 +49,8 @@ class SubjectAPI < Grape::API
         {
           name: schema_version.subject.name,
           version: schema_version.version,
-          schema: schema_version.schema.json
+          schema: schema_version.schema.json,
+          id: schema_version.schema.id
         }
       end
     end

--- a/spec/requests/subject_api_spec.rb
+++ b/spec/requests/subject_api_spec.rb
@@ -139,6 +139,18 @@ describe SubjectAPI do
       end
     end
 
+    shared_examples_for "a version lookup" do
+      before { get("/subjects/#{subject_name}/versions/#{version_id}") }
+      subject { response }
+
+      it "returns the schema and it's id" do
+        get("/subjects/#{subject_name}/versions/latest")
+        expect(response).to be_ok
+        expect(response.body).to be_json_eql(expected)
+        expect(response.body).to be_json_eql(schema.id).at_path('id')
+      end
+    end
+
     context "when the subject and version exists" do
       let!(:other_schema_version) { create(:schema_version) }
       let(:version) { create(:schema_version) }
@@ -148,22 +160,21 @@ describe SubjectAPI do
         {
           name: subject_name,
           version: version.version,
-          schema: schema.json
+          schema: schema.json,
+          id: schema.id
         }.to_json
       end
 
-      it "returns the schema" do
-        get("/subjects/#{subject_name}/versions/#{version.version}")
-        expect(response).to be_ok
-        expect(response.body).to be_json_eql(expected)
+      context "with a valid version id" do
+        let(:version_id) { version.version }
+
+        it_behaves_like "a version lookup"
       end
 
       context "when the version is specified as 'latest'" do
-        it "returns the schema" do
-          get("/subjects/#{subject_name}/versions/latest")
-          expect(response).to be_ok
-          expect(response.body).to be_json_eql(expected)
-        end
+        let(:version_id) { 'latest' }
+
+        it_behaves_like "a version lookup"
       end
 
       context "when the version is an invalid string" do


### PR DESCRIPTION
Based on the confluent schema registry [readme][l], the `GET /subjects/:name/versions/:version` endpoint should be returning the id of the schema record associated w/ the version. It looks like this differs from the [`docs.confluent.io`][link] documentation. 

This is helpful information when consuming the api (without schemas stored on the filesystem) for a particular subject.

_edit_: I suppose the schema json itself is also returned by the version api soo this is much less necessary.

| 🎩 | @jturkel |
| :--- | :--- |
| 📎 | @tjwp |


[l]: https://github.com/confluentinc/schema-registry/blob/master/README.md
[link]: https://docs.confluent.io/current/schema-registry/docs/api.html#subjects