### PR TITLE
Specify rails version in migrations

### DIFF
--- a/db/migrate/20160314152320_create_subjects.rb
+++ b/db/migrate/20160314152320_create_subjects.rb
@@ -1,4 +1,4 @@
-class CreateSubjects < ActiveRecord::Migration
+class CreateSubjects < ActiveRecord::Migration[5.0]
   def change
     create_table(:subjects, id: :bigserial) do |t|
       t.text :name, null: false

--- a/db/migrate/20160314152739_create_schemas.rb
+++ b/db/migrate/20160314152739_create_schemas.rb
@@ -1,4 +1,4 @@
-class CreateSchemas < ActiveRecord::Migration
+class CreateSchemas < ActiveRecord::Migration[5.0]
   def change
     create_table(:schemas, id: :bigserial) do |t|
       t.string :fingerprint, null: false

--- a/db/migrate/20160315151533_create_schema_versions.rb
+++ b/db/migrate/20160315151533_create_schema_versions.rb
@@ -1,4 +1,4 @@
-class CreateSchemaVersions < ActiveRecord::Migration
+class CreateSchemaVersions < ActiveRecord::Migration[5.0]
   def change
     create_table(:schema_versions, id: :bigserial) do |t|
       t.integer :version, default: 1

--- a/db/migrate/20160416174131_create_configs.rb
+++ b/db/migrate/20160416174131_create_configs.rb
@@ -1,4 +1,4 @@
-class CreateConfigs < ActiveRecord::Migration
+class CreateConfigs < ActiveRecord::Migration[5.0]
   def change
     create_table(:configs, id: :bigserial) do |t|
       t.string :compatibility


### PR DESCRIPTION
Rails 5.1 requires the version of ActiveRecord used specified when inheriting from `ActiveRecord::Migration`. I'm guessing these migrations were created in rails 4.2, but because they have the `:null` option on timestamps we can treat them as newer rails 5.0 migrations.