### PR TITLE
Allow default compatibility to be set via environment and change non-production default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## v0.12.0 (unreleased)
 - Upgrade to Ruby 2.4.2.
 - Upgrade to Rails 5.1.
+- Allow default compatibility level to be set via environment variable and
+  change the default for non-production environments.
 
 ## v0.11.0
 - Change the default fingerprint version to '2'. Set `FINGERPRINT_VERSION=1`

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -12,7 +12,6 @@
 class Config < ApplicationRecord
 
   # This default differs from the Confluent default of BACKWARD
-  DEFAULT_COMPATIBILITY = Compatibility::Constants::FULL_TRANSITIVE
   COMPATIBILITY_NAME = 'compatibility'.freeze
 
   belongs_to :subject
@@ -28,7 +27,7 @@ class Config < ApplicationRecord
 
   def self.global
     find_or_create_by!(id: 0) do |config|
-      config.compatibility = DEFAULT_COMPATIBILITY
+      config.compatibility = Rails.application.config.x.default_compatibility
     end
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,5 +38,7 @@ module AvroSchemaRegistry
     config.x.disable_schema_registration = ENV['DISABLE_SCHEMA_REGISTRATION'] == 'true'
 
     config.x.read_only_mode = ENV['READ_ONLY_MODE'] == 'true'
+
+    config.x.default_compatibility = ENV.fetch('DEFAULT_COMPATIBILITY', 'NONE')
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,4 +78,7 @@ Rails.application.configure do
   unless config.x.disable_password
     config.x.app_password = ENV.fetch('SCHEMA_REGISTRY_PASSWORD')
   end
+
+  # This default differs from the Confluent default of BACKWARD
+  config.x.default_compatibility = ENV.fetch('DEFAULT_COMPATIBILITY', 'FULL_TRANSITIVE')
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -5,4 +5,6 @@ Rails.application.configure do
   # config/environments/production.rb.
 
   config.log_level = :debug
+
+  config.x.default_compatibility = ENV.fetch('DEFAULT_COMPATIBILITY', 'NONE')
 end

--- a/config/initializers/default_compatibility.rb
+++ b/config/initializers/default_compatibility.rb
@@ -1,0 +1,3 @@
+if Compatibility::Constants::VALUES.exclude?(Rails.application.config.x.default_compatibility.upcase)
+  raise "Default compatibility '#{Rails.application.config.x.default_compatibility}' is invalid"
+end

--- a/spec/requests/subject_api_spec.rb
+++ b/spec/requests/subject_api_spec.rb
@@ -463,6 +463,11 @@ describe SubjectAPI do
     end
 
     context "when a previous version of the schema is registered under the subject" do
+      before do
+        allow(Rails.application.config.x).to receive(:default_compatibility)
+          .and_return(Compatibility::Constants::FULL_TRANSITIVE)
+      end
+
       let!(:version) { create(:schema_version) }
       let(:subject) { version.subject }
       let(:json) do


### PR DESCRIPTION
Currently, the default compatibility is hard-coded to `FULL_TRANSITIVE` for all environments.

For non-production environments it is likely that people want a more flexible default, like `NONE`, and the current setup requires a separate API request, or console modification, to change the compatibility in the global config once it has been set.

This changes the default for non-production environments, and allows the initial value to be set via the environment.

There is also an initializer to check that the configured default compatibility is valid.

Prime: @jturkel
