### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.bundle
+.env
+.envrc
+.idea
+.git
+coverage
+log
+spec
+tmp
+vendor
+**/node_modules
+**/bower_components
+deployment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Upgrade to Rails 5.1.
 - Allow default compatibility level to be set via environment variable and
   change the default for non-production environments.
+- Include Dockerfile.
 
 ## v0.11.0
 - Change the default fingerprint version to '2'. Set `FINGERPRINT_VERSION=1`

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,18 @@ RUN gem install bundler --no-document && bundle install --jobs 20 --retry 5
 
 COPY . /app
 
+# Run the app as a non-root user. The source code will be read-only,
+# but the process will complain if it can't write to tmp or log (even
+# though we're writing the logs to STDOUT).
+RUN mkdir /app/tmp /app/log
+RUN groupadd --system avro && \
+    useradd --no-log-init --system --create-home --gid avro avro && \
+    chown -R avro:avro /app/tmp /app/log
+USER avro
+
 ENV RACK_ENV=production
 ENV RAILS_ENV=production
+ENV RAILS_LOG_TO_STDOUT=true
 ENV PORT=5000
 
 EXPOSE 5000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# To build run: docker build -t avro-schema-registry .
+
+FROM ruby:2.4.2
+
+RUN mkdir /app
+WORKDIR /app
+
+# Copy the Gemfile as well as the Gemfile.lock and install
+# the RubyGems. This is a separate step so the dependencies
+# will be cached unless changes to one of those two files
+# are made.
+COPY Gemfile Gemfile.lock ./
+RUN gem install bundler --no-document && bundle install --jobs 20 --retry 5
+
+COPY . /app
+
+ENV RACK_ENV=production
+ENV RAILS_ENV=production
+ENV PORT=5000
+
+EXPOSE 5000
+
+# Start puma
+CMD bundle exec puma -C config/puma.rb

--- a/README.md
+++ b/README.md
@@ -167,6 +167,50 @@ anyone can experiment with, just please don't rely on it for production!
 
 There is also a button above to easily deploy your own copy of the application to Heroku.
 
+### Docker
+
+A Dockerfile is provided to run the application within a container. To
+build the image, navigate to the root of the repo and run `docker build`:
+
+```bash
+docker build . -t avro-schema-registry
+```
+
+The container is built for the `production` environment, so you'll
+need to pass in a few environment flags to run it:
+
+```bash
+docker run -p 5000:5000 -d \
+  -e DATABASE_URL=postgresql://user:pass@host/dbname \
+  -e FORCE_SSL=false \
+  -e SECRET_KEY_BASE=supersecret \
+  -e SCHEMA_REGISTRY_PASSWORD=avro \
+  avro-schema-registry
+```
+
+If you also want to run PostgreSQL in a container, you can link the two containers:
+
+```bash
+docker run --name avro-postgres -d \
+  -e POSTGRES_PASSWORD=avro \
+  -e POSTGRES_USER=avro \
+  postgres:9.6
+
+docker run --name avro-schema-registry --link avro-postgres:postgres -p 5000:5000 -d \
+  -e DATABASE_URL=postgresql://avro:avro@postgres/avro \
+  -e FORCE_SSL=false \
+  -e SECRET_KEY_BASE=supersecret \
+  -e SCHEMA_REGISTRY_PASSWORD=avro \
+  avro-schema-registry
+```
+
+To setup the database the first time you run the app, you can call
+`rails db:setup` from within the container:
+
+```bash
+docker exec avro-schema-registry bundle exec rails db:setup
+```
+
 ## Security
 
 The service is secured using HTTP Basic authentication and should be used with
@@ -241,4 +285,3 @@ This code is available as open source under the terms of the
 
 Bug reports and pull requests are welcome on GitHub at
 https://github.com/salsify/avro-schema-registry.
-

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,85 +1,24 @@
-# PostgreSQL. Versions 8.2 and up are supported.
-#
-# Install the pg driver:
-#   gem install pg
-# On OS X with Homebrew:
-#   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
-# On OS X with MacPorts:
-#   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
-# On Windows:
-#   gem install pg
-#       Choose the win32 build.
-#       Install PostgreSQL and put its /bin directory on your path.
-#
-# Configure Using Gemfile
-# gem 'pg'
-#
 default: &default
   adapter: postgresql
   encoding: unicode
   # For details on connection pooling, see rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
-  pool: 5
+  pool: <%= ENV.fetch('DB_POOL', 4) %>
+  port: <%= ENV['DB_PORT'] %>
+  host: <%= ENV['DB_HOST'] %>
+  username: <%= ENV['DB_USER'] %>
+  variables:
+    lock_timeout: <%= ENV.fetch('DB_LOCK_TIMEOUT', 0) %>
+    statement_timeout: <%= ENV.fetch('DB_STATEMENT_TIMEOUT', 0) %>
 
 development:
   <<: *default
   database: avro-schema-registry_development
 
-  # The specified database role being used to connect to postgres.
-  # To create additional roles in postgres see `$ createuser --help`.
-  # When left blank, postgres will use the default role. This is
-  # the same name as the operating system user that initialized the database.
-  #username: avro-schema-registry
-
-  # The password associated with the postgres role (username).
-  #password:
-
-  # Connect on a TCP socket. Omitted by default since the client uses a
-  # domain socket that doesn't need configuration. Windows does not have
-  # domain sockets, so uncomment these lines.
-  #host: localhost
-
-  # The TCP port the server listens on. Defaults to 5432.
-  # If your server runs on a different port number, change accordingly.
-  #port: 5432
-
-  # Schema search path. The server defaults to $user,public
-  #schema_search_path: myapp,sharedapp,public
-
-  # Minimum log levels, in increasing order:
-  #   debug5, debug4, debug3, debug2, debug1,
-  #   log, notice, warning, error, fatal, and panic
-  # Defaults to warning.
-  #min_messages: notice
-
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
   <<: *default
   database: avro-schema-registry_test
 
-# As with config/secrets.yml, you never want to store sensitive information,
-# like your database password, in your source code. If your source code is
-# ever seen by anyone, they now have access to your database.
-#
-# Instead, provide the password as a unix environment variable when you boot
-# the app. Read http://guides.rubyonrails.org/configuring.html#configuring-a-database
-# for a full rundown on how to provide these environment variables in a
-# production deployment.
-#
-# On Heroku and other platform providers, you may have a full connection URL
-# available as an environment variable. For example:
-#
-#   DATABASE_URL="postgres://myuser:mypass@localhost/somedatabase"
-#
-# You can use this database configuration with:
-#
-#   production:
-#     url: <%= ENV['DATABASE_URL'] %>
-#
-production:
+production: &production
   <<: *default
-  database: avro-schema-registry_production
-  username: avro-schema-registry
-  password: <%= ENV['AVRO-SCHEMA-REGISTRY_DATABASE_PASSWORD'] %>
+  url:  <%= ENV['DATABASE_URL'] %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,12 +1,25 @@
+# PostgreSQL. Versions 8.2 and up are supported.
+#
+# Install the pg driver:
+#   gem install pg
+# On OS X with Homebrew:
+#   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
+# On OS X with MacPorts:
+#   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
+# On Windows:
+#   gem install pg
+#       Choose the win32 build.
+#       Install PostgreSQL and put its /bin directory on your path.
+#
+# Configure Using Gemfile
+# gem 'pg'
+#
 default: &default
   adapter: postgresql
   encoding: unicode
   # For details on connection pooling, see rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
-  pool: <%= ENV.fetch('DB_POOL', 4) %>
-  port: <%= ENV['DB_PORT'] %>
-  host: <%= ENV['DB_HOST'] %>
-  username: <%= ENV['DB_USER'] %>
+  pool: <%= ENV.fetch('DB_POOL', 5) %>
   variables:
     lock_timeout: <%= ENV.fetch('DB_LOCK_TIMEOUT', 0) %>
     statement_timeout: <%= ENV.fetch('DB_STATEMENT_TIMEOUT', 0) %>
@@ -15,10 +28,59 @@ development:
   <<: *default
   database: avro-schema-registry_development
 
+  # The specified database role being used to connect to postgres.
+  # To create additional roles in postgres see `$ createuser --help`.
+  # When left blank, postgres will use the default role. This is
+  # the same name as the operating system user that initialized the database.
+  #username: avro-schema-registry
+
+  # The password associated with the postgres role (username).
+  #password:
+
+  # Connect on a TCP socket. Omitted by default since the client uses a
+  # domain socket that doesn't need configuration. Windows does not have
+  # domain sockets, so uncomment these lines.
+  #host: localhost
+
+  # The TCP port the server listens on. Defaults to 5432.
+  # If your server runs on a different port number, change accordingly.
+  #port: 5432
+
+  # Schema search path. The server defaults to $user,public
+  #schema_search_path: myapp,sharedapp,public
+
+  # Minimum log levels, in increasing order:
+  #   debug5, debug4, debug3, debug2, debug1,
+  #   log, notice, warning, error, fatal, and panic
+  # Defaults to warning.
+  #min_messages: notice
+
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
 test:
   <<: *default
   database: avro-schema-registry_test
 
-production: &production
+# As with config/secrets.yml, you never want to store sensitive information,
+# like your database password, in your source code. If your source code is
+# ever seen by anyone, they now have access to your database.
+#
+# Instead, provide the password as a unix environment variable when you boot
+# the app. Read http://guides.rubyonrails.org/configuring.html#configuring-a-database
+# for a full rundown on how to provide these environment variables in a
+# production deployment.
+#
+# On Heroku and other platform providers, you may have a full connection URL
+# available as an environment variable. For example:
+#
+#   DATABASE_URL="postgres://myuser:mypass@localhost/somedatabase"
+#
+# You can use this database configuration with:
+#
+#   production:
+#     url: <%= ENV['DATABASE_URL'] %>
+#
+production:
   <<: *default
-  url:  <%= ENV['DATABASE_URL'] %>
+  url: <%= ENV.fetch('DATABASE_URL') %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -83,4 +83,4 @@ test:
 #
 production:
   <<: *default
-  url: <%= ENV.fetch('DATABASE_URL') %>
+  url: <%= ENV['DATABASE_URL'] %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -75,6 +75,10 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
+  unless config.x.disable_password
+    config.x.app_password = ENV.fetch('SCHEMA_REGISTRY_PASSWORD')
+  end
+
   # This default differs from the Confluent default of BACKWARD
   config.x.default_compatibility = ENV.fetch('DEFAULT_COMPATIBILITY', 'FULL_TRANSITIVE')
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -36,11 +36,11 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  config.force_ssl = ActiveRecord::Type::Boolean.new.cast(ENV.fetch('FORCE_SSL', true))
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :info
+  config.log_level = ENV.fetch('LOG_LEVEL', :info).to_sym
 
   # Prepend all log lines with the following tags.
   # config.log_tags = [:request_id]
@@ -74,10 +74,6 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
-
-  unless config.x.disable_password
-    config.x.app_password = ENV.fetch('SCHEMA_REGISTRY_PASSWORD')
-  end
 
   # This default differs from the Confluent default of BACKWARD
   config.x.default_compatibility = ENV.fetch('DEFAULT_COMPATIBILITY', 'FULL_TRANSITIVE')

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -19,7 +19,7 @@ test:
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 production: &production
-  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  secret_key_base: <%= ENV.fetch('SECRET_KEY_BASE', '6d5987d15ed5f173ea13ee0a26ba1cb1717a86783177168ec42cebbbc563e0c3470be82eba91700659589a76ad83b2e3af5ea47f083290d563c2b321956ae964') %>
 
 staging:
   <<: *production

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -19,7 +19,7 @@ test:
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 production: &production
-  secret_key_base: <%= ENV.fetch('SECRET_KEY_BASE', '6d5987d15ed5f173ea13ee0a26ba1cb1717a86783177168ec42cebbbc563e0c3470be82eba91700659589a76ad83b2e3af5ea47f083290d563c2b321956ae964') %>
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
 
 staging:
   <<: *production


### PR DESCRIPTION
The Dockerfile assumes that we're always running the server in the `production` environment. It relaxes the production configuration a bit to allow the container to be run without specifying a secret or password. This is to make it easier to run the container locally without having to pass in a lot of environment vars.

```
$ docker build . -t avro-schema-registry
$ docker run --name avro-postgres -e POSTGRES_PASSWORD=avro \ 
    -e POSTGRES_USER=avro -d postgres:9.6
$ docker run --name avro-schema-registry --link avro-postgres:postgres \
    -p 21000:5000 -d -e DATABASE_URL=postgresql://avro:avro@postgres/avro \
    -e FORCE_SSL=false avro-schema-registry
$ docker run --link avro-postgres:postgres \
    -e DATABASE_URL=postgresql://avro:avro@postgres/avro \
    avro-schema-registry bundle exec rails db:setup
```

Prime @jturkel 
cc @jharrington22 