### PR TITLE
Dockerfile changes to enable use in CircleCI [SW-300]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avro-schema-registry
 
+## v0.13.0
+- Add auto-migrate and waiting for Postgres to the Docker container.
+
 ## v0.12.1
 - Upgrade to Puma 3.11.3.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,6 @@ FROM ruby:2.4.2
 RUN mkdir /app
 WORKDIR /app
 
-# install dockerize
-RUN wget https://github.com/jwilder/dockerize/releases/download/v0.6.1/dockerize-linux-amd64-v0.6.1.tar.gz \
-    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-v0.6.1.tar.gz \
-    && rm dockerize-linux-amd64-v0.6.1.tar.gz
-
 # Copy the Gemfile as well as the Gemfile.lock and install
 # the RubyGems. This is a separate step so the dependencies
 # will be cached unless changes to one of those two files

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,14 @@ FROM ruby:2.4.2
 RUN mkdir /app
 WORKDIR /app
 
+RUN apt-get update && apt-get install -y wget
+
+# install dockerize
+ENV DOCKERIZE_VERSION v0.6.1
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
 # Copy the Gemfile as well as the Gemfile.lock and install
 # the RubyGems. This is a separate step so the dependencies
 # will be cached unless changes to one of those two files
@@ -28,7 +36,7 @@ ENV RAILS_ENV=production
 ENV RAILS_LOG_TO_STDOUT=true
 ENV PORT=5000
 
-EXPOSE 5000
+EXPOSE $PORT
 
 # Start puma
-CMD bundle exec puma -C config/puma.rb
+CMD bin/docker_start

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,10 @@ FROM ruby:2.4.2
 RUN mkdir /app
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y wget
-
 # install dockerize
-ENV DOCKERIZE_VERSION v0.6.1
-RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+RUN wget https://github.com/jwilder/dockerize/releases/download/v0.6.1/dockerize-linux-amd64-v0.6.1.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-v0.6.1.tar.gz \
+    && rm dockerize-linux-amd64-v0.6.1.tar.gz
 
 # Copy the Gemfile as well as the Gemfile.lock and install
 # the RubyGems. This is a separate step so the dependencies
@@ -35,9 +32,6 @@ ENV RACK_ENV=production
 ENV RAILS_ENV=production
 ENV RAILS_LOG_TO_STDOUT=true
 ENV PORT=5000
-
-# set to 1 to automatically create DB and run migrations
-ENV AUTOMIGRATE=0
 
 EXPOSE $PORT
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,9 @@ ENV RAILS_ENV=production
 ENV RAILS_LOG_TO_STDOUT=true
 ENV PORT=5000
 
+# set to 1 to automatically create DB and run migrations
+ENV AUTOMIGRATE=0
+
 EXPOSE $PORT
 
 # Start puma

--- a/README.md
+++ b/README.md
@@ -211,6 +211,9 @@ To setup the database the first time you run the app, you can call
 docker exec avro-schema-registry bundle exec rails db:setup
 ```
 
+Alternatively, your can pass `-e AUTO_MIGRATE=1` to your `docker run` command to have the 
+container automatically create and migrate the database schema.
+
 ## Security
 
 The service is secured using HTTP Basic authentication and should be used with

--- a/bin/docker_start
+++ b/bin/docker_start
@@ -5,5 +5,5 @@ require 'uri'
 # check that postgres is up
 pg_uri = URI.parse(ENV['DATABASE_URL'])
 `dockerize -wait tcp://#{pg_uri.host}:#{pg_uri.port || 5432} -timeout 60s`
-`bundle exec rails db:create db:migrate`
+`bash -c 'if [ "$AUTOMIGRATE" == "1" ]; then bundle exec rails db:create db:migrate; fi'`
 `bundle exec puma -C config/puma.rb`

--- a/bin/docker_start
+++ b/bin/docker_start
@@ -1,9 +1,31 @@
 #!/usr/bin/env ruby
 
 require 'uri'
+require 'active_record'
 
 # check that postgres is up
 pg_uri = URI.parse(ENV['DATABASE_URL'])
-`dockerize -wait tcp://#{pg_uri.host}:#{pg_uri.port || 5432} -timeout 60s`
-`bash -c 'if [ "$AUTOMIGRATE" == "1" ]; then bundle exec rails db:create db:migrate; fi'`
-`bundle exec puma -C config/puma.rb`
+port = pg_uri.port || 5432
+
+unless system("dockerize -wait tcp://#{pg_uri.host}:#{port} -timeout 60s")
+  abort("Unable to connect to Postgres host at #{pg_uri.host}:#{port}")
+end
+
+user_exists = false
+60.times do
+  begin
+    puts "Waiting for DB user #{pg_uri.user}"
+    ActiveRecord::Base.establish_connection(ENV['DATABASE_URL'])
+    user_exists = true
+    break
+  rescue Exception
+    sleep(1.second)
+  end
+end
+abort("Postgres user #{pg_uri.user} does not exist") unless user_exists
+
+if ENV['AUTO_MIGRATE'] == '1'
+  abort('Unable to migrate DB') unless system('bundle exec rails db:create db:migrate')
+end
+
+exec('bundle exec puma -C config/puma.rb')

--- a/bin/docker_start
+++ b/bin/docker_start
@@ -1,4 +1,9 @@
 #!/usr/bin/env ruby
 
-dockerize -wait tcp://localhost:5432 -timeout 60s
-bundle exec puma -C config/puma.rb
+require 'uri'
+
+# check that postgres is up
+pg_uri = URI.parse(ENV['DATABASE_URL'])
+`dockerize -wait tcp://#{pg_uri.host}:#{pg_uri.port || 5432} -timeout 60s`
+`bundle exec rails db:create db:migrate`
+`bundle exec puma -C config/puma.rb`

--- a/bin/docker_start
+++ b/bin/docker_start
@@ -9,17 +9,20 @@ if ENV['AUTO_MIGRATE'] == '1'
 
   # check that we can connect to Postgres
   connected = false
+  exception = nil
   60.times do
     begin
       puts "Attempting DB connection at #{pg_uri.host}:#{port} with user #{pg_uri.user}"
       ActiveRecord::Base.establish_connection(ENV['DATABASE_URL'])
+      ActiveRecord::Base.connection
       connected = true
       break
-    rescue Exception
+    rescue StandardError => e
+      exception = e
       sleep(1.second)
     end
   end
-  abort("Unable to connect to Postgres host at #{pg_uri.host}:#{port} with user #{pg_uri.user}") unless connected
+  raise exception unless connected
 
   # create and migrate DB
   abort('Unable to migrate DB') unless system('bundle exec rails db:create db:migrate')

--- a/bin/docker_start
+++ b/bin/docker_start
@@ -4,27 +4,22 @@ require 'uri'
 require 'active_record'
 
 if ENV['AUTO_MIGRATE'] == '1'
-  # check that postgres is up
   pg_uri = URI.parse(ENV['DATABASE_URL'])
   port = pg_uri.port || 5432
 
-  unless system("dockerize -wait tcp://#{pg_uri.host}:#{port} -timeout 60s")
-    abort("Unable to connect to Postgres host at #{pg_uri.host}:#{port}")
-  end
-
-  # check that postgres user exists
-  user_exists = false
+  # check that we can connect to Postgres
+  connected = false
   60.times do
     begin
-      puts "Waiting for DB user #{pg_uri.user}"
+      puts "Attempting DB connection at #{pg_uri.host}:#{port} with user #{pg_uri.user}"
       ActiveRecord::Base.establish_connection(ENV['DATABASE_URL'])
-      user_exists = true
+      connected = true
       break
     rescue Exception
       sleep(1.second)
     end
   end
-  abort("Postgres user #{pg_uri.user} does not exist") unless user_exists
+  abort("Unable to connect to Postgres host at #{pg_uri.host}:#{port} with user #{pg_uri.user}") unless connected
 
   # create and migrate DB
   abort('Unable to migrate DB') unless system('bundle exec rails db:create db:migrate')

--- a/bin/docker_start
+++ b/bin/docker_start
@@ -3,28 +3,30 @@
 require 'uri'
 require 'active_record'
 
-# check that postgres is up
-pg_uri = URI.parse(ENV['DATABASE_URL'])
-port = pg_uri.port || 5432
-
-unless system("dockerize -wait tcp://#{pg_uri.host}:#{port} -timeout 60s")
-  abort("Unable to connect to Postgres host at #{pg_uri.host}:#{port}")
-end
-
-user_exists = false
-60.times do
-  begin
-    puts "Waiting for DB user #{pg_uri.user}"
-    ActiveRecord::Base.establish_connection(ENV['DATABASE_URL'])
-    user_exists = true
-    break
-  rescue Exception
-    sleep(1.second)
-  end
-end
-abort("Postgres user #{pg_uri.user} does not exist") unless user_exists
-
 if ENV['AUTO_MIGRATE'] == '1'
+  # check that postgres is up
+  pg_uri = URI.parse(ENV['DATABASE_URL'])
+  port = pg_uri.port || 5432
+
+  unless system("dockerize -wait tcp://#{pg_uri.host}:#{port} -timeout 60s")
+    abort("Unable to connect to Postgres host at #{pg_uri.host}:#{port}")
+  end
+
+  # check that postgres user exists
+  user_exists = false
+  60.times do
+    begin
+      puts "Waiting for DB user #{pg_uri.user}"
+      ActiveRecord::Base.establish_connection(ENV['DATABASE_URL'])
+      user_exists = true
+      break
+    rescue Exception
+      sleep(1.second)
+    end
+  end
+  abort("Postgres user #{pg_uri.user} does not exist") unless user_exists
+
+  # create and migrate DB
   abort('Unable to migrate DB') unless system('bundle exec rails db:create db:migrate')
 end
 

--- a/bin/docker_start
+++ b/bin/docker_start
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+
+dockerize -wait tcp://localhost:5432 -timeout 60s
+bundle exec puma -C config/puma.rb

--- a/bin/docker_start
+++ b/bin/docker_start
@@ -10,16 +10,19 @@ if ENV['AUTO_MIGRATE'] == '1'
   # check that we can connect to Postgres
   connected = false
   exception = nil
+  connection = nil
   60.times do
     begin
       puts "Attempting DB connection at #{pg_uri.host}:#{port} with user #{pg_uri.user}"
       ActiveRecord::Base.establish_connection(ENV['DATABASE_URL'])
-      ActiveRecord::Base.connection
+      connection = ActiveRecord::Base.connection
       connected = true
       break
     rescue StandardError => e
       exception = e
       sleep(1.second)
+    ensure
+      connection.close unless connection.nil?
     end
   end
   raise exception unless connected


### PR DESCRIPTION
This enables avro-schema-registry's docker images to be used by Dandelion's tests on CircleCI.

Docker on Circle has a few limitations that needed to be addressed:
1. Circle doesn't allow for port mapping. This change plumbs to `PORT` env so it can be overridden to 21000 in Dandelion's `circle.yml`.
2. Circle doesn't allow running commands in containers which means there was no way to setup the schema registry's DB. This change adds a `docker_start` script to run the DB setup commands. It also installs [Dockerize](https://github.com/jwilder/dockerize) which already used in Circle so we can wait for PG to come up before attempting to create and migrate the DB.

Implementation can be seen in my Dandelion branch: https://github.com/salsify/dandelion/blob/e5606b9d5c6ab8352f34d29755f3022d448f7e86/circle.yml#L269

@atsheehan prime

[[SW-300]](https://salsify.atlassian.net/browse/SW-300)

A well shaved yak:
![11436330375_4039e613d8_n](https://user-images.githubusercontent.com/1123109/39070184-5236fbce-44b0-11e8-877f-9d1b930169c2.jpg)
