### PR TITLE
Catch missing database exception [SW-300]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avro-schema-registry
 
+## v0.13.1
+- Missing database no longer causes `docker_start` script to fail in auto-migrate mode.
+
 ## v0.13.0
 - Add auto-migrate and waiting for Postgres to the Docker container.
 

--- a/bin/docker_start
+++ b/bin/docker_start
@@ -18,6 +18,10 @@ if ENV['AUTO_MIGRATE'] == '1'
       connection = ActiveRecord::Base.connection
       connected = true
       break
+    rescue ActiveRecord::NoDatabaseError
+      # `NoDatabaseError` error is OK, we'll create the DB below
+      connected = true
+      break
     rescue StandardError => e
       exception = e
       sleep(1.second)


### PR DESCRIPTION
Catches the exception for missing database. This block only needs to care about connecting to Postgres: the database is created later.

@jturkel prime

[[SW-300]](https://salsify.atlassian.net/browse/SW-300)