### PR TITLE
Pause between determining the DB is up and running migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avro-schema-registry
 
+## v0.13.2
+- Missing database no longer causes `docker_start` script to fail in auto-migrate mode.
+
 ## v0.13.1
 - Missing database no longer causes `docker_start` script to fail in auto-migrate mode.
 

--- a/bin/docker_start
+++ b/bin/docker_start
@@ -24,12 +24,15 @@ if ENV['AUTO_MIGRATE'] == '1'
       break
     rescue StandardError => e
       exception = e
-      sleep(1.second)
+      sleep(2.second)
     ensure
       connection.close unless connection.nil?
     end
   end
   raise exception unless connected
+
+  # the PG driver is slow to release its port binding: https://www.postgresql.org/message-id/30038.1494916166%40sss.pgh.pa.us
+  sleep(2.second)
 
   # create and migrate DB
   abort('Unable to migrate DB') unless system('bundle exec rails db:create db:migrate')


### PR DESCRIPTION
In Circle we're seeing the following error:
```
could not connect to server: Connection refused
    Is the server running on host "localhost" (127.0.0.1) and accepting
    TCP/IP connections on port 5432?
could not connect to server: Cannot assign requested address
    Is the server running on host "localhost" (::1) and accepting
    TCP/IP connections on port 5432?
Couldn't create database for {"adapter"=>"postgresql", "encoding"=>"unicode", "pool"=>5, "variables"=>{"lock_timeout"=>0, "statement_timeout"=>0}, "username"=>"ubuntu", "database"=>"avro-schema-registry_test", "host"=>"localhost"}
W, [2018-04-27T18:56:25.996533 #448]  WARN -- : ** [Bugsnag] No API key configured, couldn't notify
rails aborted!
```

This is [caused](https://www.postgresql.org/message-id/30038.1494916166%40sss.pgh.pa.us) by the Postgres client being slow to release its port binding. 

This fix increases the pause between DB connection attempts and adds a pause between the successful DB connection and the DB creation and migration attempt.

@dadleyy prime