### PR TITLE
Allow hyphens in subject names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # avro-schema-registry
 
+## v0.13.4 (unreleased)
+- Allow hyphens in subject names.
+
 ## v0.13.3
 - Upgrade to avro-patches 0.3.4
 

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -11,7 +11,7 @@
 class Subject < ApplicationRecord
   include ImmutableModel
 
-  NAME_REGEXP = /[a-zA-Z_][\w\.]*/
+  NAME_REGEXP = /[a-zA-Z_][\w\.\-]*/
 
   has_one :config # rubocop:disable Rails/HasManyOrHasOneDependent
   has_many :versions, class_name: 'SchemaVersion', inverse_of: :subject # rubocop:disable Rails/HasManyOrHasOneDependent

--- a/spec/requests/subject_api_spec.rb
+++ b/spec/requests/subject_api_spec.rb
@@ -97,7 +97,7 @@ describe SubjectAPI do
                       '5alive'
 
       it_behaves_like "an unsupported subject name",
-                      'a name containing a hyphen',
+                      'a name beginning with a hyphen',
                       '-foobar'
 
       it_behaves_like "an unsupported subject name",

--- a/spec/requests/subject_api_spec.rb
+++ b/spec/requests/subject_api_spec.rb
@@ -88,13 +88,17 @@ describe SubjectAPI do
                       'a name containing mixed case',
                       'UPPER_lower_0123456789'
 
+      it_behaves_like "a supported subject name",
+                      'a name containing a hyphen',
+                      'topic-value'
+
       it_behaves_like "an unsupported subject name",
                       'a name beginning with a digit',
                       '5alive'
 
       it_behaves_like "an unsupported subject name",
                       'a name containing a hyphen',
-                      'foo-bar'
+                      '-foobar'
 
       it_behaves_like "an unsupported subject name",
                       'a name beginning with a period',


### PR DESCRIPTION
The original restriction was based on the assumption that a subject name would be the concatenation of an Avro namespace and an Avro schema name with a period.

Some of the Confluent tools don't follow that assumption so this change adds hyphens to the allowed list of characters within a subject name. Hyphen is still disallowed as the first character.

This fixes https://github.com/salsify/avro-schema-registry/issues/89