### PR TITLE
Endpoint to return unescaped schema

### DIFF
--- a/app/api/base_api.rb
+++ b/app/api/base_api.rb
@@ -8,10 +8,10 @@ module BaseAPI
 
   SCHEMA_REGISTRY_V1_CONTENT_TYPE = 'application/vnd.schemaregistry.v1+json'
   SCHEMA_REGISTRY_CONTENT_TYPE = 'application/vnd.schemaregistry.json'
-  JSON = 'application/json'
+  JSON_CONTENT_TYPE = 'application/json'
 
   included do
-    content_type :json, JSON
+    content_type :json, JSON_CONTENT_TYPE
     content_type :schema_registry, SCHEMA_REGISTRY_CONTENT_TYPE
     content_type :schema_registry_v1, SCHEMA_REGISTRY_V1_CONTENT_TYPE
 

--- a/app/api/subject_api.rb
+++ b/app/api/subject_api.rb
@@ -41,18 +41,27 @@ class SubjectAPI < Grape::API
         end
     end
 
-    desc 'Get a specific version of the schema registered under this subject'
     params do
       requires :version_id, types: [Integer, String],
                desc: 'version of the schema registered under the subject'
     end
-    get '/versions/:version_id' do
-      with_schema_version(params[:name], params[:version_id]) do |schema_version|
-        {
-          name: schema_version.subject.name,
-          version: schema_version.version,
-          schema: schema_version.schema.json
-        }
+    namespace '/versions/:version_id' do
+      desc 'Get a specific version of the schema registered under this subject'
+      get do
+        with_schema_version(params[:name], params[:version_id]) do |schema_version|
+          {
+            name: schema_version.subject.name,
+            version: schema_version.version,
+            schema: schema_version.schema.json
+          }
+        end
+      end
+
+      desc 'Get the Avro schema for the specified version of this subject. Only the unescaped schema is returned.'
+      get '/schema' do
+        with_schema_version(params[:name], params[:version_id]) do |schema_version|
+          ::JSON.parse(schema_version.schema.json)
+        end
       end
     end
 

--- a/app/api/subject_api.rb
+++ b/app/api/subject_api.rb
@@ -60,7 +60,7 @@ class SubjectAPI < Grape::API
       desc 'Get the Avro schema for the specified version of this subject. Only the unescaped schema is returned.'
       get '/schema' do
         with_schema_version(params[:name], params[:version_id]) do |schema_version|
-          ::JSON.parse(schema_version.schema.json)
+          JSON.parse(schema_version.schema.json)
         end
       end
     end


### PR DESCRIPTION
This fixes #110. 

This endpoint is part of the current Confluent API and easy to support based on the functionality that was already present.

As part of this change, I also renamed a constant that had the potential to cause some confusion.