### PR TITLE
Enable Travis gem caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 dist: trusty
 language: ruby
+cache: bundler
 rvm:
   - 2.6.3
 services:


### PR DESCRIPTION
Enable Travis' gem [caching](https://docs.travis-ci.com/user/caching/) to cut CI time from about 2 minutes to about 1 minute.