### PR TITLE
Use a more secure password comparison to avoid timing attacks

### DIFF
--- a/app/api/base_api.rb
+++ b/app/api/base_api.rb
@@ -28,7 +28,7 @@ module BaseAPI
         type: :http_basic,
         realm: 'API Authorization',
         proc: ->(_username, password) do
-          password == Rails.configuration.x.app_password
+          ActiveSupport::SecurityUtils.secure_compare(password, Rails.configuration.x.app_password)
         end
   end
 end


### PR DESCRIPTION
Comparing passwords with `==`'s is not sufficient to avoid a timing attack. 

Both sides instead should be hashed or similar before comparison. ActiveSupport actually provides a method just for this so it's an easy swap 😄 .

Don't think you had any tests around this that I could see? Tested it locally though and can still auth fine.