### PR TITLE
Add the schema ID to the GET /subject/:subject/versions/... response

### DIFF
--- a/app/api/subject_api.rb
+++ b/app/api/subject_api.rb
@@ -50,6 +50,7 @@ class SubjectAPI < Grape::API
       get do
         with_schema_version(params[:name], params[:version_id]) do |schema_version|
           {
+            id: schema_version.schema_id,
             name: schema_version.subject.name,
             version: schema_version.version,
             schema: schema_version.schema.json

--- a/spec/requests/subject_api_spec.rb
+++ b/spec/requests/subject_api_spec.rb
@@ -150,8 +150,10 @@ describe SubjectAPI do
       let(:version) { create(:schema_version) }
       let(:subject_name) { version.subject.name }
       let(:schema) { version.schema }
+
       let(:expected) do
         {
+          id: version.schema_id,
           name: subject_name,
           version: version.version,
           schema: schema.json
@@ -161,6 +163,7 @@ describe SubjectAPI do
       it "returns the schema" do
         get("/subjects/#{subject_name}/versions/#{version.version}")
         expect(response).to be_ok
+        expect(JSON.parse(response.body)['id']).to eq(version.schema_id)
         expect(response.body).to be_json_eql(expected)
       end
 


### PR DESCRIPTION
Avro Turf requires the schema ID to be present in the response to GET /subject/:subject/versions/:version. Without the ID, an exception is raised and caching in Avro Turf fails. 
