### PR TITLE
Allow all hosts to connect in dev mode; do not dump schema

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
   end
 
   # Do not dump the schema if the environment has DO_NOT_DUMP_SCHEMA set to any value.
-  config.active_record.dump_schema_after_migration = !ENV.key?('DO_NOT_DUMP_SCHEMA')
+  config.active_record.dump_schema_after_migration = ENV.fetch('DUMP_SCHEMA_AFTER_MIGRATION', 'true') == 'true'
 
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -4,7 +4,9 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Allow additional hosts to connect. Provide hostnames as a comma-separated list.
-  ENV.fetch('PERMITTED_HOSTS', nil).tap do |permitted_hosts|
+  # TODO: Rails 7 supports RAILS_DEVELOPMENT_HOSTS out of the box. Delete this
+  # entire section when the schema registry is ported to Rails 7.
+  ENV.fetch('RAILS_DEVELOPMENT_HOSTS', nil).tap do |permitted_hosts|
     config.hosts = permitted_hosts.split(',').map(&:strip).reject(&:blank?) if permitted_hosts
   end
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -3,11 +3,13 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  # Do not dump schema automatically after migrations
-  config.active_record.dump_schema_after_migration = false
+  # Allow additional hosts to connect. Provide hostnames as a comma-separated list.
+  ENV.fetch('PERMITTED_HOSTS', nil).tap do |permitted_hosts|
+    config.hosts = permitted_hosts.split(',').map(&:strip).reject(&:blank?) if permitted_hosts
+  end
 
-  # Allow all hosts to connect
-  config.hosts = nil
+  # Do not dump the schema if the environment has DO_NOT_DUMP_SCHEMA set to any value.
+  config.active_record.dump_schema_after_migration = !ENV.key?('DO_NOT_DUMP_SCHEMA')
 
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -3,6 +3,12 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Do not dump schema automatically after migrations
+  config.active_record.dump_schema_after_migration = false
+
+  # Allow all hosts to connect
+  config.hosts = nil
+
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.


### PR DESCRIPTION
In dev mode, allow all hosts to connect, such as other containers in a docker compose collection. Do not dump the schema after migrating, since the filesystem may not be writeable in a container. 