### PR TITLE
Use upstream Ruby image for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: salsify/ruby_ci:2.7.8
+      - image: ruby:2.7.8
       - image: cimg/postgres:14.7
         environment:
           POSTGRES_USER: "ubuntu"


### PR DESCRIPTION
Use the official Ruby image in CI as we use nothing that our internal CI image configures.

prime @jturkel 