### PR TITLE
Fix Puma config

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -9,6 +9,5 @@ threads threads_count, threads_count
 
 preload_app!
 
-rackup      DefaultRackup
 port        ENV['PORT']     || 21000
 environment ENV['RACK_ENV'] || 'development'


### PR DESCRIPTION
Our Puma config broke in https://github.com/salsify/avro-schema-registry/pull/401 leading to errors like this:

```
12:46:08 web.1  | NameError: uninitialized constant #<Class:#<Puma::DSL:0x000000011e0c8b30>>::DefaultRackup
12:46:08 web.1  |   config/puma.rb:12:in `_load_from'
12:46:08 web.1  |   /Users/jturkel/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/puma-6.4.0/lib/puma/dsl.rb:133:in `instance_eval'
12:46:08 web.1  |   /Users/jturkel/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/puma-6.4.0/lib/puma/dsl.rb:133:in `_load_from'
12:46:08 web.1  |   /Users/jturkel/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/puma-6.4.0/lib/puma/configuration.rb:239:in `block in load'
12:46:08 web.1  |   /Users/jturkel/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/puma-6.4.0/lib/puma/configuration.rb:239:in `each'
12:46:08 web.1  |   /Users/jturkel/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/puma-6.4.0/lib/puma/configuration.rb:239:in `load'
12:46:08 web.1  |   /Users/jturkel/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/puma-6.4.0/lib/puma/launcher.rb:54:in `initialize'
12:46:08 web.1  |   /Users/jturkel/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/puma-6.4.0/lib/puma/cli.rb:66:in `new'
12:46:08 web.1  |   /Users/jturkel/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/puma-6.4.0/lib/puma/cli.rb:66:in `initialize'
12:46:08 web.1  |   /Users/jturkel/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/puma-6.4.0/bin/puma:8:in `new'
12:46:08 web.1  |   /Users/jturkel/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/puma-6.4.0/bin/puma:8:in `<top (required)>'
12:46:08 web.1  |   /Users/jturkel/.rbenv/versions/2.7.8/bin/puma:23:in `load'
12:46:08 web.1  |   /Users/jturkel/.rbenv/versions/2.7.8/bin/puma:23:in `<top (required)>'
```
Fortunately the fix is pretty straightforward as described in https://github.com/puma/puma/issues/2989.