### PR TITLE
Fix docker build failure due to bundler dependency on Ruby 3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app
 # will be cached unless changes to one of those two files
 # are made.
 COPY Gemfile Gemfile.lock ./
-RUN gem install bundler --no-document && bundle install --jobs 20 --retry 5
+RUN gem install bundler -v 2.4.22 --no-document && bundle install --jobs 20 --retry 5
 
 COPY . /app
 


### PR DESCRIPTION
The latest 2.5.x version of Bundler depends on Ruby 3.x, so the docker build fails currently. This pins the bundler version to 2.4.2.