### PR TITLE
[PIMCORE-4981] Migrate Staging DB to IAM auth

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'avro-resolution_canonical_form', '>= 0.2.0'
 gem 'bootsnap', require: false
 gem 'grape', '~> 2.2.0' # newer versions result in content-type issues
 gem 'pg'
+gem 'pg-aws_rds_iam'
 gem 'private_attr', require: 'private_attr/everywhere'
 gem 'puma', '>= 5.6.7'
 gem 'rails', '~> 7.2.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,21 @@ GEM
     avro_turf (1.14.0)
       avro (>= 1.8.0, < 1.12)
       excon (~> 0.104)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1266.0)
+    aws-sdk-core (3.252.0)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-rds (1.316.0)
+      aws-sdk-core (~> 3, >= 3.248.0)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.3.0)
     benchmark (0.5.0)
     bigdecimal (4.0.1)
@@ -151,6 +166,7 @@ GEM
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    jmespath (1.6.2)
     json (2.19.2)
     json_spec (1.1.5)
       multi_json (~> 1.0)
@@ -201,6 +217,9 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.6.3)
+    pg-aws_rds_iam (0.8.0)
+      aws-sdk-rds (~> 1.0)
+      pg (~> 1.3)
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -362,6 +381,7 @@ DEPENDENCIES
   newrelic_rpm
   overcommit
   pg
+  pg-aws_rds_iam
   private_attr
   puma (>= 5.6.7)
   rails (~> 7.2.2)

--- a/config/database.yml
+++ b/config/database.yml
@@ -24,3 +24,6 @@ production:
   <<: *default
   url: <%= ENV['DATABASE_URL'] %>
 
+staging:
+  <<: *default
+  url: <%= ENV['DATABASE_URL_IAM'] || ENV['DATABASE_URL'] %>

--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Aws.config.update(
+  region: 'us-east-1'
+)


### PR DESCRIPTION
Following [these](https://salsify.atlassian.net/wiki/spaces/ENG/pages/261934678024/RDS+IAM+Auth+Migration+Plan+for+Rails+Apps#Step-2%3A-Update-the-Rails-Project) steps to migrate the staging avro-schema-registry db to use iam based auth.

I opted with a specific url override in staging to avoid having the production database immediately assume the iam auth once the terraform PR would land

prime @erikkessler1 
